### PR TITLE
Vikas dev

### DIFF
--- a/src/modules/AbstractField/src/AbstractField_Class.F90
+++ b/src/modules/AbstractField/src/AbstractField_Class.F90
@@ -83,13 +83,15 @@ TYPE, ABSTRACT :: AbstractField_
   LOGICAL(LGT) :: isMaxTotalNodeNumForBCSet = math%no
   !! It is true when we set the maxTotalNodeNumForBC
   !! see, nodeNum, nodalValue, and GetMaxTotalNodeNumForBC
+  LOGICAL(LGT) :: saveErrorNorm = math%no
+  !! save error norm
+  LOGICAL(LGT) :: plotWithResult = math%no
+  !! do you want to plot exact solution with result
+  LOGICAL(LGT) :: plotErrorNorm = math%no
+  !! plot error norm
+
   INTEGER(I4B) :: fieldType = TypeField%normal
   !! fieldType can be normal, constant, can vary in space and/ or both.
-  TYPE(String) :: name
-  !! name of the field
-  TYPE(String) :: engine
-  !! Engine of the field, for example
-  !! NATIVE_SERIAL, NATIVE_OMP, NATIVE_MPI, PETSC, LIS_OMP, LIS_MPI
   INTEGER(I4B) :: maxTotalNodeNumForBC = math%zero_i
   !! maximum total node num for applying boundary conditions
   !! see, nodeNum, nodalValue, and GetMaxTotalNodeNumForBC
@@ -111,6 +113,14 @@ TYPE, ABSTRACT :: AbstractField_
   !! lis_ptr is pointer returned by the LIS library
   !! It is used when engine is LIS_OMP or LIS_MPI
 
+  TYPE(String) :: name
+  !! name of the field
+  TYPE(String) :: engine
+  !! Engine of the field, for example
+  !! NATIVE_SERIAL, NATIVE_OMP, NATIVE_MPI, PETSC, LIS_OMP, LIS_MPI
+  CHARACTER(4) :: errorType = "NONE"
+  !! errorType
+
   TYPE(DOF_) :: dof
   !! Degree of freedom object,
   !! which contains the information about how the different
@@ -130,13 +140,6 @@ TYPE, ABSTRACT :: AbstractField_
   TYPE(UserFunction_), POINTER :: exact => NULL()
   !! reference function for displacement
   !! Reference displacement denotes the exact solution
-  LOGICAL(LGT) :: saveErrorNorm = math%no
-  !! save error norm
-  CHARACTER(4) :: errorType = "NONE"
-  !! errorType
-  LOGICAL(LGT) :: plotWithResult = math%no
-  !! do you want to plot exact solution with result
-  LOGICAL(LGT) :: plotErrorNorm = math%no
 
   TYPE(DirichletBCPointer_), ALLOCATABLE :: dbc(:)
   !! Dirichlet boundary conditions
@@ -592,9 +595,17 @@ INTERFACE AbstractFieldImport
 END INTERFACE AbstractFieldImport
 
 !----------------------------------------------------------------------------
-!                                                          Export@IOMethods
+!                                                          Export@HDFMethods
 !----------------------------------------------------------------------------
 
+!> author: Vikas Sharma, Ph. D.
+! date: 2026-07-01
+! summary: Export AbstractField to HDF5 file
+!
+!# Export
+!
+! Export AbstractField data to HDF5 file.
+!
 INTERFACE
   MODULE SUBROUTINE obj_Export(obj, hdf5, group)
     CLASS(AbstractField_), INTENT(INOUT) :: obj

--- a/src/modules/AbstractNodeField/src/AbstractNodeField_Class.F90
+++ b/src/modules/AbstractNodeField/src/AbstractNodeField_Class.F90
@@ -486,15 +486,11 @@ END INTERFACE
 ! date:  2023-11-24
 ! summary:  Export data in vtkfile
 
-INTERFACE
+INTERFACE AbstractNodeFieldWriteData
   MODULE SUBROUTINE obj_WriteData_vtk1(obj, vtk)
     CLASS(AbstractNodeField_), INTENT(INOUT) :: obj
     TYPE(VTKFile_), INTENT(INOUT) :: vtk
   END SUBROUTINE obj_WriteData_vtk1
-END INTERFACE
-
-INTERFACE AbstractNodeFieldWriteData
-  MODULE PROCEDURE obj_WriteData_vtk1
 END INTERFACE AbstractNodeFieldWriteData
 
 !----------------------------------------------------------------------------
@@ -505,15 +501,11 @@ END INTERFACE AbstractNodeFieldWriteData
 ! date:   2023-12-21
 ! summary:  Export data in vtkfile
 
-INTERFACE
+INTERFACE AbstractNodeFieldWriteData
   MODULE SUBROUTINE obj_WriteData_vtk2(obj, vtk)
     CLASS(AbstractNodeFieldPointer_), INTENT(INOUT) :: obj(:)
     TYPE(VTKFile_), INTENT(INOUT) :: vtk
   END SUBROUTINE obj_WriteData_vtk2
-END INTERFACE
-
-INTERFACE AbstractNodeFieldWriteData
-  MODULE PROCEDURE obj_WriteData_vtk2
 END INTERFACE AbstractNodeFieldWriteData
 
 INTERFACE NodeFieldsWriteData

--- a/src/modules/AbstractNodeField/src/AbstractNodeField_Class.F90
+++ b/src/modules/AbstractNodeField/src/AbstractNodeField_Class.F90
@@ -71,6 +71,10 @@ TYPE, ABSTRACT, EXTENDS(AbstractField_) :: AbstractNodeField_
   !! Storage format
   !! note: This variable is only for internal use
 
+  INTEGER(I4B) :: tSize = 0
+  !! Total length of the nodal field = tdof * tNodes
+  !! note: This variable is only for internal use
+
   INTEGER(I4B), ALLOCATABLE :: dof_spaceCompo(:)
   !! Spatial components
   !! note: This variable is only for internal use
@@ -84,10 +88,6 @@ TYPE, ABSTRACT, EXTENDS(AbstractField_) :: AbstractNodeField_
 
   CHARACTER(1), ALLOCATABLE :: dof_names_char(:)
   !! Single character name of physical variable
-  !! note: This variable is only for internal use
-
-  INTEGER(I4B) :: tSize = 0
-  !! Total length of the nodal field = tdof * tNodes
   !! note: This variable is only for internal use
 
   TYPE(RealVector_) :: realVec
@@ -457,52 +457,7 @@ INTERFACE AbstractNodeFieldDisplay
 END INTERFACE AbstractNodeFieldDisplay
 
 !----------------------------------------------------------------------------
-!                                                            IMPORT@IOMethods
-!----------------------------------------------------------------------------
-
-!> author: Vikas Sharma, Ph. D.
-! date:  2023-11-24
-! summary:  Import data into HDF5File_
-
-INTERFACE
-  MODULE SUBROUTINE obj_Import(obj, hdf5, group, fedof, fedofs, timefedof, &
-                               timefedofs, geofedof, geofedofs)
-    CLASS(AbstractNodeField_), INTENT(INOUT) :: obj
-    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
-    CHARACTER(*), INTENT(IN) :: group
-    CLASS(FEDOF_), TARGET, OPTIONAL, INTENT(IN) :: fedof, geofedof
-    TYPE(FEDOFPointer_), OPTIONAL, INTENT(IN) :: fedofs(:), geofedofs(:)
-    CLASS(TimeFEDOF_), TARGET, OPTIONAL, INTENT(IN) :: timefedof
-    TYPE(TimeFEDOFPointer_), OPTIONAL, INTENT(IN) :: timefedofs(:)
-  END SUBROUTINE obj_Import
-END INTERFACE
-
-INTERFACE AbstractNodeFieldImport
-  MODULE PROCEDURE obj_Import
-END INTERFACE AbstractNodeFieldImport
-
-!----------------------------------------------------------------------------
-!                                                         Export@IOMethods
-!----------------------------------------------------------------------------
-
-!> author: Vikas Sharma, Ph. D.
-! date:  2023-11-24
-! summary:  Export data into HDF5File_
-
-INTERFACE
-  MODULE SUBROUTINE obj_Export(obj, hdf5, group)
-    CLASS(AbstractNodeField_), INTENT(INOUT) :: obj
-    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
-    CHARACTER(*), INTENT(IN) :: group
-  END SUBROUTINE obj_Export
-END INTERFACE
-
-INTERFACE AbstractNodeFieldExport
-  MODULE PROCEDURE obj_Export
-END INTERFACE AbstractNodeFieldExport
-
-!----------------------------------------------------------------------------
-!                                                     ExportToVTK@IOMethods
+!                                                     ExportToVTK@VTKMethods
 !----------------------------------------------------------------------------
 
 !> author: Vikas Sharma, Ph. D.
@@ -1141,6 +1096,51 @@ INTERFACE
     CLASS(AbstractNodeField_), INTENT(INOUT) :: obj
   END SUBROUTINE obj_Reciprocal
 END INTERFACE
+
+!----------------------------------------------------------------------------
+!                                                          IMPORT@HDFMethods
+!----------------------------------------------------------------------------
+
+!> author: Vikas Sharma, Ph. D.
+! date:  2023-11-24
+! summary:  Import abstract node field data from HDF5File_
+
+INTERFACE
+  MODULE SUBROUTINE obj_Import(obj, hdf5, group, fedof, fedofs, timefedof, &
+                               timefedofs, geofedof, geofedofs)
+    CLASS(AbstractNodeField_), INTENT(INOUT) :: obj
+    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
+    CHARACTER(*), INTENT(IN) :: group
+    CLASS(FEDOF_), TARGET, OPTIONAL, INTENT(IN) :: fedof, geofedof
+    TYPE(FEDOFPointer_), OPTIONAL, INTENT(IN) :: fedofs(:), geofedofs(:)
+    CLASS(TimeFEDOF_), TARGET, OPTIONAL, INTENT(IN) :: timefedof
+    TYPE(TimeFEDOFPointer_), OPTIONAL, INTENT(IN) :: timefedofs(:)
+  END SUBROUTINE obj_Import
+END INTERFACE
+
+INTERFACE AbstractNodeFieldImport
+  MODULE PROCEDURE obj_Import
+END INTERFACE AbstractNodeFieldImport
+
+!----------------------------------------------------------------------------
+!                                                         Export@HDFMethods
+!----------------------------------------------------------------------------
+
+!> author: Vikas Sharma, Ph. D.
+! date:  2023-11-24
+! summary:  Export data into HDF5File_
+
+INTERFACE
+  MODULE SUBROUTINE obj_Export(obj, hdf5, group)
+    CLASS(AbstractNodeField_), INTENT(INOUT) :: obj
+    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
+    CHARACTER(*), INTENT(IN) :: group
+  END SUBROUTINE obj_Export
+END INTERFACE
+
+INTERFACE AbstractNodeFieldExport
+  MODULE PROCEDURE obj_Export
+END INTERFACE AbstractNodeFieldExport
 
 !----------------------------------------------------------------------------
 !

--- a/src/modules/HDF5File/src/HDF5FileUtility.F90
+++ b/src/modules/HDF5File/src/HDF5FileUtility.F90
@@ -41,18 +41,27 @@ PUBLIC :: ExportRealVector
 PUBLIC :: ImportRealVector
 PUBLIC :: ExportIntVector
 PUBLIC :: ImportIntVector
+
 PUBLIC :: HDF5ReadScalar
 PUBLIC :: HDF5ReadVector
 PUBLIC :: HDF5ReadMatrix
+
 PUBLIC :: HDF5GetEntities
+
+PUBLIC :: HDF5WriteVector
+PUBLIC :: HDF5WriteMatrix
+
+! PUBLIC :: ExportCharVector
+! PUBLIC :: ExportCharMatrix
+! PUBLIC :: ImportCharVector
+! PUBLIC :: ImportCharMatrix
 
 !----------------------------------------------------------------------------
 !                                                            HDF5GetEntities
 !----------------------------------------------------------------------------
 
 INTERFACE
-  MODULE SUBROUTINE HDF5GetEntities( &
-    hdf5, group, dim, tEntities)
+  MODULE SUBROUTINE HDF5GetEntities(hdf5, group, dim, tEntities)
     CLASS(HDF5File_), INTENT(INOUT) :: hdf5
     CHARACTER(*), INTENT(IN) :: group
     INTEGER(I4B), INTENT(IN) :: dim
@@ -65,8 +74,7 @@ END INTERFACE
 !----------------------------------------------------------------------------
 
 INTERFACE HDF5ReadMatrix
-  MODULE SUBROUTINE HDF5ReadIntMatrix( &
-    hdf5, VALUE, group, fieldname, check)
+  MODULE SUBROUTINE HDF5ReadIntMatrix(hdf5, VALUE, group, fieldname, check)
     TYPE(HDF5File_), INTENT(INOUT) :: hdf5
     INTEGER(I4B), ALLOCATABLE, INTENT(INOUT) :: VALUE(:, :)
     CHARACTER(*), INTENT(IN) :: group
@@ -80,8 +88,7 @@ END INTERFACE HDF5ReadMatrix
 !----------------------------------------------------------------------------
 
 INTERFACE HDF5ReadMatrix
-  MODULE SUBROUTINE HDF5ReadRealMatrix( &
-    hdf5, VALUE, group, fieldname, check)
+  MODULE SUBROUTINE HDF5ReadRealMatrix(hdf5, VALUE, group, fieldname, check)
     TYPE(HDF5File_), INTENT(INOUT) :: hdf5
     REAL(DFP), ALLOCATABLE, INTENT(INOUT) :: VALUE(:, :)
     CHARACTER(*), INTENT(IN) :: group
@@ -95,8 +102,7 @@ END INTERFACE HDF5ReadMatrix
 !----------------------------------------------------------------------------
 
 INTERFACE HDF5ReadVector
-  MODULE SUBROUTINE HDF5ReadRealVector( &
-    hdf5, VALUE, group, fieldname, check)
+  MODULE SUBROUTINE HDF5ReadRealVector(hdf5, VALUE, group, fieldname, check)
     TYPE(HDF5File_), INTENT(INOUT) :: hdf5
     REAL(DFP), ALLOCATABLE, INTENT(INOUT) :: VALUE(:)
     CHARACTER(*), INTENT(IN) :: group
@@ -110,8 +116,7 @@ END INTERFACE HDF5ReadVector
 !----------------------------------------------------------------------------
 
 INTERFACE HDF5ReadVector
-  MODULE SUBROUTINE HDF5ReadIntVector( &
-    hdf5, VALUE, group, fieldname, check)
+  MODULE SUBROUTINE HDF5ReadIntVector(hdf5, VALUE, group, fieldname, check)
     TYPE(HDF5File_), INTENT(INOUT) :: hdf5
     INTEGER(I4B), ALLOCATABLE, INTENT(INOUT) :: VALUE(:)
     CHARACTER(*), INTENT(IN) :: group
@@ -125,8 +130,7 @@ END INTERFACE HDF5ReadVector
 !----------------------------------------------------------------------------
 
 INTERFACE
-  MODULE SUBROUTINE HDF5ReadScalar( &
-    hdf5, VALUE, group, fieldname, check)
+  MODULE SUBROUTINE HDF5ReadScalar(hdf5, VALUE, group, fieldname, check)
     TYPE(HDF5File_), INTENT(INOUT) :: hdf5
     CLASS(*), INTENT(INOUT) :: VALUE
     CHARACTER(*), INTENT(IN) :: group
@@ -254,6 +258,60 @@ INTERFACE
     CHARACTER(*), INTENT(IN) :: group
   END SUBROUTINE ImportIntVector
 END INTERFACE
+
+!----------------------------------------------------------------------------
+!                                                            HDF5WriteVector
+!----------------------------------------------------------------------------
+
+INTERFACE HDF5WriteVector
+  MODULE SUBROUTINE HDF5WriteCharVector(hdf5, VALUE, group, fieldname)
+    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
+    CHARACTER(*), INTENT(IN) :: VALUE(:)
+    CHARACTER(*), INTENT(IN) :: group
+    CHARACTER(*), INTENT(IN) :: fieldname
+  END SUBROUTINE HDF5WriteCharVector
+END INTERFACE HDF5WriteVector
+
+!----------------------------------------------------------------------------
+!                                                            HDF5WriteMatrix
+!----------------------------------------------------------------------------
+
+INTERFACE HDF5WriteMatrix
+  MODULE SUBROUTINE HDF5WriteCharMatrix(hdf5, VALUE, group, fieldname)
+    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
+    CHARACTER(*), INTENT(IN) :: VALUE(:, :)
+    CHARACTER(*), INTENT(IN) :: group
+    CHARACTER(*), INTENT(IN) :: fieldname
+  END SUBROUTINE HDF5WriteCharMatrix
+END INTERFACE HDF5WriteMatrix
+
+!----------------------------------------------------------------------------
+!                                                            HDF5ReadVector
+!----------------------------------------------------------------------------
+
+INTERFACE HDF5ReadVector
+  MODULE SUBROUTINE HDF5ReadCharVector(hdf5, VALUE, group, fieldname, check)
+    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
+    CHARACTER(:), ALLOCATABLE, INTENT(INOUT) :: VALUE(:)
+    CHARACTER(*), INTENT(IN) :: group
+    CHARACTER(*), INTENT(IN) :: fieldname
+    LOGICAL(LGT), INTENT(IN) :: check
+  END SUBROUTINE HDF5ReadCharVector
+END INTERFACE HDF5ReadVector
+
+!----------------------------------------------------------------------------
+!                                                            HDF5ReadMatrix
+!----------------------------------------------------------------------------
+
+INTERFACE HDF5ReadMatrix
+  MODULE SUBROUTINE HDF5ReadCharMatrix(hdf5, VALUE, group, fieldname, check)
+    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
+    CHARACTER(:), ALLOCATABLE, INTENT(INOUT) :: VALUE(:, :)
+    CHARACTER(*), INTENT(IN) :: group
+    CHARACTER(*), INTENT(IN) :: fieldname
+    LOGICAL(LGT), INTENT(IN) :: check
+  END SUBROUTINE HDF5ReadCharMatrix
+END INTERFACE HDF5ReadMatrix
 
 !----------------------------------------------------------------------------
 !

--- a/src/modules/HDF5File/src/HDF5FileUtility.F90
+++ b/src/modules/HDF5File/src/HDF5FileUtility.F90
@@ -51,11 +51,6 @@ PUBLIC :: HDF5GetEntities
 PUBLIC :: HDF5WriteVector
 PUBLIC :: HDF5WriteMatrix
 
-! PUBLIC :: ExportCharVector
-! PUBLIC :: ExportCharMatrix
-! PUBLIC :: ImportCharVector
-! PUBLIC :: ImportCharMatrix
-
 !----------------------------------------------------------------------------
 !                                                            HDF5GetEntities
 !----------------------------------------------------------------------------

--- a/src/modules/HDF5File/src/HDF5File_Class.F90
+++ b/src/modules/HDF5File/src/HDF5File_Class.F90
@@ -546,7 +546,7 @@ END INTERFACE
 
 INTERFACE
  MODULE SUBROUTINE preWrite( obj,rank,gdims,ldims,path,mem,dset_id,dspace_id,&
-               & gspace_id, plist_id, error, cnt, offset)
+                 & gspace_id, plist_id, error, cnt, offset)
     CLASS(HDF5File_), INTENT(INOUT) :: obj
     INTEGER, INTENT(IN) :: rank
     INTEGER(HSIZE_T), INTENT(IN) :: gdims(:)
@@ -1293,7 +1293,7 @@ END INTERFACE
 
 INTERFACE
  MODULE SUBROUTINE hdf5_write_st1(obj, dsetname, vals, length_max, gdims_in, &
-               & cnt_in, offset_in)
+                 & cnt_in, offset_in)
     CLASS(HDF5File_), INTENT(INOUT) :: obj
     !! HDF5 data type
     CHARACTER(LEN=*), INTENT(IN) :: dsetname
@@ -1343,7 +1343,7 @@ END INTERFACE
 
 INTERFACE
  MODULE SUBROUTINE hdf5_write_st2(obj, dsetname, vals, length_max, gdims_in, &
-               & cnt_in, offset_in)
+                 & cnt_in, offset_in)
     CLASS(HDF5File_), INTENT(INOUT) :: obj
     !! HDF5 data type
     CHARACTER(LEN=*), INTENT(IN) :: dsetname
@@ -1393,7 +1393,7 @@ END INTERFACE
 
 INTERFACE
  MODULE SUBROUTINE hdf5_write_st3(obj, dsetname, vals, length_max, gdims_in, &
-               & cnt_in, offset_in)
+                 & cnt_in, offset_in)
     CLASS(HDF5File_), INTENT(INOUT) :: obj
     !! HDF5 data type
     CHARACTER(LEN=*), INTENT(IN) :: dsetname

--- a/src/modules/ScalarField/src/ScalarField_Class.F90
+++ b/src/modules/ScalarField/src/ScalarField_Class.F90
@@ -44,6 +44,7 @@ PUBLIC :: ScalarField_
 PUBLIC :: ScalarFieldPointer_
 PUBLIC :: ScalarFieldInitiate
 PUBLIC :: ScalarFieldImport
+PUBLIC :: ScalarFieldExport
 PUBLIC :: ScalarFieldDeallocate
 PUBLIC :: ScalarFieldSafeAllocate
 PUBLIC :: ScalarFieldApplyBodySource
@@ -65,13 +66,11 @@ TYPE, EXTENDS(AbstractNodeField_) :: ScalarField_
 CONTAINS
   PRIVATE
 
-  ! CONSTRUCTOR:
   ! @ConstructorMethods
   PROCEDURE, PUBLIC, PASS(obj) :: Initiate2 => obj_Initiate2
   !! Initiate an instance of ScalarField_ by passing arguments
   FINAL :: obj_Final
 
-  ! SET:
   ! @SetMethods
   PROCEDURE, NON_OVERRIDABLE, PASS(obj) :: Set1 => obj_Set1
   !! Set single entry, we call SetSingle method
@@ -99,7 +98,6 @@ CONTAINS
   GENERIC, PUBLIC :: ASSIGNMENT(=) => Set7
   !! Set values to a vector
 
-  ! GET:
   ! @GetMethods
   PROCEDURE, NON_OVERRIDABLE, PASS(obj) :: Get1 => obj_Get1
   !! Get single entry
@@ -119,7 +117,6 @@ CONTAINS
   PROCEDURE, PUBLIC, PASS(obj) :: GetMeshField => obj_GetMeshField
   !! Get the mesh field corresponding to abstract field
 
-  ! SET:
   ! @DBCMethods
   PROCEDURE, NON_OVERRIDABLE, PASS(obj) :: ApplyDirichletBC1 => &
     obj_ApplyDirichletBC1
@@ -133,12 +130,10 @@ CONTAINS
   GENERIC, PUBLIC :: ApplyDirichletBC => ApplyDirichletBC1, &
     ApplyDirichletBC2, ApplyDirichletBC3
 
-  ! SET:
   ! @PointNBCMethods
   PROCEDURE, PUBLIC, NON_OVERRIDABLE, PASS(obj) :: ApplyPointNeumannBC => &
     obj_ApplyPointNeumannBC
 
-  ! SET:
   ! @SurfaceNBCMethods
   PROCEDURE, PUBLIC, NON_OVERRIDABLE, PASS(obj) :: &
     ApplySurfaceNeumannBC1 => obj_ApplySurfaceNeumannBC1
@@ -150,7 +145,6 @@ CONTAINS
     ApplySurfaceNeumannBC2
   !! Generic method for applying surface neumann boundary conditions
 
-  ! SET:
   ! @BodySourceMethods
   PROCEDURE, NON_OVERRIDABLE, PASS(obj) :: ApplyBodySource1 => &
     obj_ApplyBodySource1
@@ -163,14 +157,16 @@ CONTAINS
   GENERIC, PUBLIC :: ApplyBodySource => ApplyBodySource1, ApplyBodySource2
   !! Generic method for setting body source
 
-  ! IO:
-  ! @IOMethods
+  ! @HDFMethods
   PROCEDURE, PUBLIC, PASS(obj) :: IMPORT => obj_Import
   !! Import data from HDF5 file
+  PROCEDURE, PUBLIC, PASS(obj) :: Export => obj_Export
+  !! Export data from HDF5 file
+
+  ! @VTKMethods
   PROCEDURE, PUBLIC, PASS(obj) :: ExportToVTK => obj_ExportToVTK
 
-  ! IO:
-  ! @IOMethods
+  ! @TomlMethods
   PROCEDURE, PUBLIC, PASS(obj) :: SetFromToml => obj_SetFromToml
   !! Initiate from toml
 END TYPE ScalarField_
@@ -293,7 +289,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                             Deallocate@ConstructorMethods
+!                                              Deallocate@ConstructorMethods
 !----------------------------------------------------------------------------
 
 !> author: Vikas Sharma, Ph. D.
@@ -335,53 +331,6 @@ END INTERFACE
 INTERFACE ScalarFieldSafeAllocate
   MODULE PROCEDURE obj_ScalarFieldSafeAllocate1
 END INTERFACE ScalarFieldSafeAllocate
-
-!----------------------------------------------------------------------------
-!                                                                Import@IO
-!----------------------------------------------------------------------------
-
-!> authors: Vikas Sharma, Ph. D.
-! date: 16 July 2021
-! summary: This routine Imports the content
-
-INTERFACE
-  MODULE SUBROUTINE obj_Import(obj, hdf5, group, fedof, fedofs, timefedof, &
-                               timefedofs, geofedof, geofedofs)
-    CLASS(ScalarField_), INTENT(INOUT) :: obj
-    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
-    CHARACTER(*), INTENT(IN) :: group
-    CLASS(FEDOF_), TARGET, OPTIONAL, INTENT(IN) :: fedof, geofedof
-    TYPE(FEDOFPointer_), OPTIONAL, INTENT(IN) :: fedofs(:), geofedofs(:)
-    CLASS(TimeFEDOF_), TARGET, OPTIONAL, INTENT(IN) :: timefedof
-    TYPE(TimeFEDOFPointer_), OPTIONAL, INTENT(IN) :: timefedofs(:)
-  END SUBROUTINE obj_Import
-END INTERFACE
-
-INTERFACE ScalarFieldImport
-  MODULE PROCEDURE obj_Import
-END INTERFACE ScalarFieldImport
-
-!----------------------------------------------------------------------------
-!                                                     ExportToVTK@IOMethods
-!----------------------------------------------------------------------------
-
-!> author: Vikas Sharma, Ph. D.
-! date:  2024-07-29
-! summary:  This routine called during WriteData_vtk
-!
-!# Introduction
-!
-! This routine is called during WriteData_vtk
-! It should be implemented by the child class
-
-INTERFACE
-  MODULE SUBROUTINE obj_ExportToVTK(obj, vtk)
-    CLASS(ScalarField_), INTENT(INOUT) :: obj
-    !! node field object
-    TYPE(VTKFile_), INTENT(INOUT) :: vtk
-    !! vtkfile object
-  END SUBROUTINE obj_ExportToVTK
-END INTERFACE
 
 !----------------------------------------------------------------------------
 !                                                           Set@SetMethods
@@ -429,7 +378,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Set@SetMethods
+!                                                             Set@SetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -446,7 +395,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Set@SetMethods
+!                                                             Set@SetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -471,7 +420,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Set@SetMethods
+!                                                             Set@SetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -496,7 +445,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Set@SetMethods
+!                                                             Set@SetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -522,7 +471,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Set@SetMethods
+!                                                             Set@SetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -537,7 +486,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Set@SetMethods
+!                                                             Set@SetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -552,35 +501,6 @@ INTERFACE
     LOGICAL(LGT), INTENT(IN) :: addContribution
   END SUBROUTINE obj_Set8
 END INTERFACE
-
-!----------------------------------------------------------------------------
-!                                                            Set@SetMethods
-!----------------------------------------------------------------------------
-
-!> author: Vikas Sharma, Ph. D.
-! date: 2024-05-23
-! summary: Set
-
-! INTERFACE
-!   MODULE SUBROUTINE obj_Set9( &
-!     obj, ivar, idof, VALUE, ivar_value, idof_value, scale, addContribution)
-!     CLASS(ScalarField_), INTENT(INOUT) :: obj
-!     INTEGER(I4B), INTENT(IN) :: ivar
-!     !! physical variable of obj
-!     INTEGER(I4B), INTENT(IN) :: idof
-!     !! local degree of freedom of physical variable ivar
-!     CLASS(AbstractNodeField_), INTENT(IN) :: VALUE
-!     !! right hand side in obj = value
-!     INTEGER(I4B), INTENT(IN) :: ivar_value
-!     !! physical variable of value
-!     INTEGER(I4B), INTENT(IN) :: idof_value
-!     !! local degree of freedom of physical variable ivar_value
-!     REAL(DFP), OPTIONAL, INTENT(IN) :: scale
-!     !! scale
-!     LOGICAL(LGT), OPTIONAL, INTENT(IN) :: addContribution
-!     !! add or set
-!   END SUBROUTINE obj_Set9
-! END INTERFACE
 
 !----------------------------------------------------------------------------
 !                                                   SetByFunction@SetMethods
@@ -607,7 +527,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Get@GetMethods
+!                                                             Get@GetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -628,7 +548,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Get@GetMethods
+!                                                             Get@GetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -646,7 +566,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Get@GetMethods
+!                                                            Get@GetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -668,7 +588,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                           Get@GetMethods
+!                                                             Get@GetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -686,30 +606,6 @@ INTERFACE
     !! if true, then globalNodes are local nodes
   END SUBROUTINE obj_Get4
 END INTERFACE
-
-! !----------------------------------------------------------------------------
-! !                                                             Get@GetMethods
-! !----------------------------------------------------------------------------
-!
-! !> author: Vikas Sharma, Ph. D.
-! ! date: 2024-06-05
-! ! summary: value@[ivar, idof] = obj@[ivar, idof]
-!
-! INTERFACE
-!   MODULE SUBROUTINE obj_Get6(obj, ivar, idof, VALUE, ivar_value, idof_value)
-!     CLASS(ScalarField_), INTENT(IN) :: obj
-!     CLASS(AbstractNodeField_), INTENT(INOUT) :: VALUE
-!     !! obj = value
-!     INTEGER(I4B), INTENT(IN) :: ivar
-!     !! physical variable in obj
-!     INTEGER(I4B), INTENT(IN) :: idof
-!     !! local degree of freedom in obj (physical variable)
-!     INTEGER(I4B), INTENT(IN) :: ivar_value
-!     !! physical variable in value
-!     INTEGER(I4B), INTENT(IN) :: idof_value
-!     !! local degree of freedom in value (physical variable)
-!   END SUBROUTINE obj_Get6
-! END INTERFACE
 
 !----------------------------------------------------------------------------
 !                                                   GetFEVariable@GetMethods
@@ -767,7 +663,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                               ApplyDirichletBC@DBCMethods
+!                                                ApplyDirichletBC@DBCMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -783,7 +679,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                               ApplyDirichletBC@DBCMethods
+!                                                ApplyDirichletBC@DBCMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -799,7 +695,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                               ApplyDirichletBC@DBCMethods
+!                                                ApplyDirichletBC@DBCMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -859,7 +755,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                   ApplyNeumannBC@NBCMethods
+!                                                  ApplyNeumannBC@NBCMethods
 !----------------------------------------------------------------------------
 
 !> author: Vikas Sharma, Ph. D.
@@ -936,7 +832,7 @@ INTERFACE ScalarFieldApplyBodySource
 END INTERFACE ScalarFieldApplyBodySource
 
 !----------------------------------------------------------------------------
-!                                                SetFromToml@TomlMethods
+!                                                    SetFromToml@TomlMethods
 !----------------------------------------------------------------------------
 
 !> author: Vikas Sharma, Ph. D.
@@ -948,6 +844,77 @@ INTERFACE
     CLASS(ScalarField_), INTENT(INOUT) :: obj
     TYPE(toml_table), INTENT(INOUT) :: table
   END SUBROUTINE obj_SetFromToml
+END INTERFACE
+
+!----------------------------------------------------------------------------
+!                                                          Import@HDFMethods
+!----------------------------------------------------------------------------
+
+!> authors: Vikas Sharma, Ph. D.
+! date: 2026-07-01
+! summary: This routine Imports the content of scalar field from HDF5File
+
+INTERFACE
+  MODULE SUBROUTINE obj_Import(obj, hdf5, group, fedof, fedofs, timefedof, &
+                               timefedofs, geofedof, geofedofs)
+    CLASS(ScalarField_), INTENT(INOUT) :: obj
+    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
+    CHARACTER(*), INTENT(IN) :: group
+    CLASS(FEDOF_), TARGET, OPTIONAL, INTENT(IN) :: fedof, geofedof
+    TYPE(FEDOFPointer_), OPTIONAL, INTENT(IN) :: fedofs(:), geofedofs(:)
+    CLASS(TimeFEDOF_), TARGET, OPTIONAL, INTENT(IN) :: timefedof
+    TYPE(TimeFEDOFPointer_), OPTIONAL, INTENT(IN) :: timefedofs(:)
+  END SUBROUTINE obj_Import
+END INTERFACE
+
+INTERFACE ScalarFieldImport
+  MODULE PROCEDURE obj_Import
+END INTERFACE ScalarFieldImport
+
+!----------------------------------------------------------------------------
+!                                                          Export@HDFMethods
+!----------------------------------------------------------------------------
+
+!> author: Vikas Sharma, Ph. D.
+! date: 2026-07-01
+! summary: Export the content of ScalarField to HDF5 file.
+!
+!# Export
+!
+! Export the content of ScalarField to HDF5 file.
+
+INTERFACE
+  MODULE SUBROUTINE obj_Export(obj, hdf5, group)
+    CLASS(ScalarField_), INTENT(INOUT) :: obj
+    TYPE(HDF5File_), INTENT(INOUT) :: hdf5
+    CHARACTER(*), INTENT(IN) :: group
+  END SUBROUTINE obj_Export
+END INTERFACE
+
+INTERFACE ScalarFieldExport
+  MODULE PROCEDURE obj_Export
+END INTERFACE ScalarFieldExport
+
+!----------------------------------------------------------------------------
+!                                                     ExportToVTK@VTKMethods
+!----------------------------------------------------------------------------
+
+!> author: Vikas Sharma, Ph. D.
+! date:  2026-07-01
+! summary:  This routine called during WriteData_vtk
+!
+!# ExportToVTK
+!
+! This routine is called during WriteData_vtk.
+! It should be implemented by the child class
+
+INTERFACE
+  MODULE SUBROUTINE obj_ExportToVTK(obj, vtk)
+    CLASS(ScalarField_), INTENT(INOUT) :: obj
+    !! node field object
+    TYPE(VTKFile_), INTENT(INOUT) :: vtk
+    !! vtkfile object
+  END SUBROUTINE obj_ExportToVTK
 END INTERFACE
 
 !----------------------------------------------------------------------------

--- a/src/modules/ScalarField/src/ScalarField_Class.F90
+++ b/src/modules/ScalarField/src/ScalarField_Class.F90
@@ -906,7 +906,6 @@ END INTERFACE ScalarFieldExport
 !# ExportToVTK
 !
 ! This routine is called during WriteData_vtk.
-! It should be implemented by the child class
 
 INTERFACE
   MODULE SUBROUTINE obj_ExportToVTK(obj, vtk)

--- a/src/submodules/AbstractField/src/AbstractField_Class@HDFMethods.F90
+++ b/src/submodules/AbstractField/src/AbstractField_Class@HDFMethods.F90
@@ -17,12 +17,15 @@
 SUBMODULE(AbstractField_Class) HDFMethods
 USE Display_Method, ONLY: Display, ToString
 USE FieldOpt_Class, ONLY: TypeField => TypeFieldOpt
+USE HDF5FileUtility, ONLY: ExportDOF
+
 IMPLICIT NONE
 
 #ifdef DEBUG_VER
 CHARACTER(*), PARAMETER :: modName = &
                            "AbstractField_Class@HDFMethods.F90"
 #endif
+
 CONTAINS
 
 !----------------------------------------------------------------------------
@@ -32,10 +35,10 @@ CONTAINS
 MODULE PROCEDURE obj_Export
 #ifdef DEBUG_VER
 CHARACTER(*), PARAMETER :: myName = "obj_Export()"
-LOGICAL(LGT) :: isok
 #endif
 
 TYPE(String) :: dname
+LOGICAL(LGT) :: isok
 
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &
@@ -62,52 +65,95 @@ CALL AssertError1(isok, myName, &
                   'hdf5 file does not have write permission')
 #endif
 
+! Bool0
+! ---------
+! isInit
+dname = TRIM(group)//"/Bool0/isInit"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%isInit)
+
+! isMaxTotalNodeNumForBCSet
+dname = TRIM(group)//"/Bool0/isMaxTotalNodeNumForBCSet"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%isMaxTotalNodeNumForBCSet)
+
+! saveErrorNorm
+dname = TRIM(group)//"/Bool0/saveErrorNorm"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%saveErrorNorm)
+
+! plotWithResult
+dname = TRIM(group)//"/Bool0/plotWithResult"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%plotWithResult)
+
+! plotErrorNorm
+dname = TRIM(group)//"/Bool0/plotErrorNorm"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%plotErrorNorm)
+
+! IntR0
+! ---------
 ! fieldType
-dname = TRIM(group)//"/fieldType"
+dname = TRIM(group)//"/IntR0/fieldType"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%fieldType)
+
+! maxTotalNodeNumForBC
+dname = TRIM(group)//"/IntR0/maxTotalNodeNumForBC"
 CALL hdf5%WRITE(dsetname=dname%chars(), &
-                vals=STRING(TypeField%ToString(obj%fieldType)))
-
-! name
-dname = TRIM(group)//"/name"
-CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%name)
-
-! engine
-dname = TRIM(group)//"/engine"
-CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%engine)
+                vals=obj%maxTotalNodeNumForBC)
 
 ! comm
-dname = TRIM(group)//"/comm"
+dname = TRIM(group)//"/IntR0/comm"
 CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%comm)
 
 ! myRank
-dname = TRIM(group)//"/myRank"
+dname = TRIM(group)//"/IntR0/myRank"
 CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%myRank)
 
 ! numProcs
-dname = TRIM(group)//"/numProcs"
+dname = TRIM(group)//"/IntR0/numProcs"
 CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%numProcs)
 
-! local_n
-dname = TRIM(group)//"/local_n"
-CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%local_n)
-
 ! global_n
-dname = TRIM(group)//"/global_n"
+dname = TRIM(group)//"/IntR0/global_n"
 CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%global_n)
 
+! local_n
+dname = TRIM(group)//"/IntR0/local_n"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%local_n)
+
 ! is
-dname = TRIM(group)//"/is"
+dname = TRIM(group)//"/IntR0/is"
 CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%is)
 
 ! ie
-dname = TRIM(group)//"/ie"
+dname = TRIM(group)//"/IntR0/ie"
 CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%ie)
+
+! lis_ptr
+dname = TRIM(group)//"/IntR0/lis_ptr"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=math%zero_i)
+
+! String0
+! engine
+dname = TRIM(group)//"/StringR0/name"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%name)
+
+! engine
+dname = TRIM(group)//"/StringR0/engine"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%engine)
+
+! errorType
+dname = TRIM(group)//"/StringR0/errorType"
+CALL hdf5%WRITE(dsetname=dname%chars(), vals=String(obj%errorType))
+
+! DOFR0
+dname = TRIM(group)//"/DOFR0/dof"
+CALL ExportDOF(obj=obj%dof, hdf5=hdf5, group=dname%Chars())
+
+! fedof, geofedof, fedofs, geofedofs, timefedof, timefedofs,
+! exact, dbc, nbc, nbc_point, nodalValue, and nodeNum are not exported
 
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &
                         '[END] ')
 #endif
-
 END PROCEDURE obj_Export
 
 !----------------------------------------------------------------------------
@@ -117,7 +163,6 @@ END PROCEDURE obj_Export
 MODULE PROCEDURE obj_Import
 CHARACTER(*), PARAMETER :: myName = "obj_Import()"
 LOGICAL(LGT) :: isok
-
 TYPE(String) :: strval, dsetname
 INTEGER(I4B) :: tsize, ii
 
@@ -126,155 +171,159 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
                         '[START] ')
 #endif
 
-! main program
 #ifdef DEBUG_VER
 isok = .NOT. obj%IsInitiated()
 CALL AssertError1(isok, myName, &
                   'The instance of AbstractField_ is already initiated')
 #endif
 
-! Check
 #ifdef DEBUG_VER
 isok = hdf5%isOpen()
-CALL AssertError1(isok, myName, &
-                  'HDF5 file is not opened')
+CALL AssertError1(isok, myName, 'HDF5 file is not opened')
 #endif
 
-! Check
 #ifdef DEBUG_VER
 isok = hdf5%isRead()
-CALL AssertError1(isok, myName, &
-                  'HDF5 file does not have read permission')
+CALL AssertError1(isok, myName, 'HDF5 file does not have read permission')
 #endif
 
-! fieldType
-dsetname = TRIM(group)//"/fieldType"
-IF (hdf5%pathExists(dsetname%chars())) THEN
-  CALL hdf5%READ(dsetname=dsetname%chars(), vals=strval)
-  obj%fieldType = TypeField%ToNumber(strval%chars())
-ELSE
-  obj%fieldType = TypeField%normal
+obj%isInit = math%yes
+
+! Bool0
+
+dsetname = TRIM(group)//"/Bool0/isMaxTotalNodeNumForBCSet"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), &
+                 vals=obj%isMaxTotalNodeNumForBCSet)
 END IF
 
-! name
-dsetname = TRIM(group)//"/name"
-
-#ifdef DEBUG_VER
+dsetname = TRIM(group)//"/Bool0/saveErrorNorm"
 isok = hdf5%pathExists(dsetname%chars())
-CALL AssertError1(isok, myName, &
-                  'The dataset name should be present')
-#endif
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), &
+                 vals=obj%saveErrorNorm)
+END IF
 
-CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%name)
-
-! engine
-dsetname = TRIM(group)//"/engine"
-#ifdef DEBUG_VER
+dsetname = TRIM(group)//"/Bool0/plotWithResult"
 isok = hdf5%pathExists(dsetname%chars())
-CALL AssertError1(isok, myName, &
-                  'The dataset engine should be present')
-#endif
-CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%engine)
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), &
+                 vals=obj%plotWithResult)
+END IF
+
+dsetname = TRIM(group)//"/Bool0/plotErrorNorm"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), &
+                 vals=obj%plotErrorNorm)
+END IF
+
+! IntR0
+
+! fieldType
+dsetname = TRIM(group)//"/IntR0/fieldType"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%fieldType)
+END IF
+
+! maxTotalNodeNumForBC
+dsetname = TRIM(group)//"/IntR0/maxTotalNodeNumForBC"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%maxTotalNodeNumForBC)
+END IF
 
 ! comm
-dsetname = TRIM(group)//"/comm"
+dsetname = TRIM(group)//"/IntR0/comm"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) THEN
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%comm)
-ELSE
-  obj%comm = 0
 END IF
 
 ! myRank
-dsetname = TRIM(group)//"/myRank"
+dsetname = TRIM(group)//"/IntR0/myRank"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) THEN
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%myRank)
-ELSE
-  obj%myRank = 0
 END IF
 
 ! numProcs
-dsetname = TRIM(group)//"/numProcs"
+dsetname = TRIM(group)//"/IntR0/numProcs"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) THEN
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%numProcs)
-ELSE
-  obj%numProcs = 1
 END IF
 
 ! global_n
-dsetname = TRIM(group)//"/global_n"
+dsetname = TRIM(group)//"/IntR0/global_n"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) THEN
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%global_n)
-ELSE
-  obj%global_n = 1
 END IF
 
 ! local_n
-dsetname = TRIM(group)//"/local_n"
+dsetname = TRIM(group)//"/IntR0/local_n"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) THEN
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%local_n)
-ELSE
-  obj%local_n = 1
 END IF
 
 ! is
-dsetname = TRIM(group)//"/is"
+dsetname = TRIM(group)//"/IntR0/is"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) THEN
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%is)
-ELSE
-  obj%is = 1
 END IF
 
 ! ie
-dsetname = TRIM(group)//"/ie"
+dsetname = TRIM(group)//"/IntR0/ie"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) THEN
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%ie)
-ELSE
-  obj%ie = 1
 END IF
 
-#ifdef DEBUG_VER
-isok = .NOT. ASSOCIATED(obj%fedof)
-CALL AssertError1(isok, myName, &
-                  'AbstractField_::obj%fedof is already associated')
-#endif
+! lis_ptr
+! dsetname = TRIM(group)//"/IntR0/lis_ptr"
+! isok = hdf5%pathExists(dsetname%chars())
+! IF (isok) THEN
+!   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%lis_ptr)
+! END IF
 
-#ifdef DEBUG_VER
-isok = .NOT. ALLOCATED(obj%fedofs)
-CALL AssertError1(isok, myName, &
-                  'AbstractField_::obj%fedofs is already allocated')
-#endif
+! StringR0
+! --------
 
-obj%isInit = .TRUE.
+! name
+dsetname = TRIM(group)//"/StringR0/name"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%name)
+END IF
+
+! engine
+dsetname = TRIM(group)//"/StringR0/engine"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%engine)
+END IF
+
+! errorType
+dsetname = TRIM(group)//"/StringR0/errorType"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%chars(), vals=strval)
+  obj%errorType = strval%Slice(1, 4)
+END IF
 
 isok = PRESENT(fedof)
 IF (isok) THEN
   obj%fedof => fedof
-
-#ifdef DEBUG_VER
-  CALL e%RaiseInformation(modName//'::'//myName//' - '// &
-                          '[END] ')
-#endif
-
-  RETURN
 END IF
 
 isok = PRESENT(geofedof)
 IF (isok) THEN
   obj%geofedof => geofedof
-
-#ifdef DEBUG_VER
-  CALL e%RaiseInformation(modName//'::'//myName//' - '// &
-                          '[END] ')
-#endif
-
-  RETURN
 END IF
 
 isok = PRESENT(fedofs)
@@ -285,13 +334,6 @@ IF (isok) THEN
   DO ii = 1, tsize
     obj%fedofs(ii)%ptr => fedofs(ii)%ptr
   END DO
-
-#ifdef DEBUG_VER
-  CALL e%RaiseInformation(modName//'::'//myName//' - '// &
-                          '[END] ')
-#endif
-
-  RETURN
 END IF
 
 isok = PRESENT(geofedofs)
@@ -302,20 +344,22 @@ IF (isok) THEN
   DO ii = 1, tsize
     obj%geofedofs(ii)%ptr => geofedofs(ii)%ptr
   END DO
-
-#ifdef DEBUG_VER
-  CALL e%RaiseInformation(modName//'::'//myName//' - '// &
-                          '[END] ')
-#endif
-
-  RETURN
 END IF
 
-#ifdef DEBUG_VER
-CALL AssertError1(.FALSE., myName, &
-                  "For non-rectangle matrix dom should be present, "// &
-                  "for rectangle matrix matrix fedofs should be present")
-#endif
+isok = PRESENT(timefedof)
+IF (isok) THEN
+  obj%timefedof => timefedof
+END IF
+
+isok = PRESENT(timefedofs)
+IF (isok) THEN
+  tsize = SIZE(timefedofs)
+  ALLOCATE (obj%timefedofs(tsize))
+
+  DO ii = 1, tsize
+    obj%timefedofs(ii)%ptr => timefedofs(ii)%ptr
+  END DO
+END IF
 
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &

--- a/src/submodules/AbstractField/src/AbstractField_Class@HDFMethods.F90
+++ b/src/submodules/AbstractField/src/AbstractField_Class@HDFMethods.F90
@@ -18,6 +18,7 @@ SUBMODULE(AbstractField_Class) HDFMethods
 USE Display_Method, ONLY: Display, ToString
 USE FieldOpt_Class, ONLY: TypeField => TypeFieldOpt
 USE HDF5FileUtility, ONLY: ExportDOF
+USE HDF5FileUtility, ONLY: ImportDOF
 
 IMPLICIT NONE
 
@@ -143,8 +144,8 @@ CALL hdf5%WRITE(dsetname=dname%chars(), vals=obj%engine)
 dname = TRIM(group)//"/StringR0/errorType"
 CALL hdf5%WRITE(dsetname=dname%chars(), vals=String(obj%errorType))
 
-! DOFR0
-dname = TRIM(group)//"/DOFR0/dof"
+! DofR0
+dname = TRIM(group)//"/DofR0/dof"
 CALL ExportDOF(obj=obj%dof, hdf5=hdf5, group=dname%Chars())
 
 ! fedof, geofedof, fedofs, geofedofs, timefedof, timefedofs,
@@ -314,6 +315,14 @@ isok = hdf5%pathExists(dsetname%chars())
 IF (isok) THEN
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=strval)
   obj%errorType = strval%Slice(1, 4)
+  strval = ""
+END IF
+
+! DofR0
+dsetname = TRIM(group)//"/DofR0/dof"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL ImportDOF(obj=obj%dof, hdf5=hdf5, group=dsetname%Chars())
 END IF
 
 isok = PRESENT(fedof)

--- a/src/submodules/AbstractNodeField/src/AbstractNodeField_Class@HDFMethods.F90
+++ b/src/submodules/AbstractNodeField/src/AbstractNodeField_Class@HDFMethods.F90
@@ -16,13 +16,13 @@
 
 SUBMODULE(AbstractNodeField_Class) HDFMethods
 USE String_Class, ONLY: String
+USE BaseType, ONLY: math => TypeMathOpt
 USE AbstractField_Class, ONLY: AbstractFieldImport
 USE AbstractField_Class, ONLY: AbstractFieldExport
 USE HDF5FileUtility, ONLY: ImportRealVector
 USE HDF5FileUtility, ONLY: ImportDOF
 USE HDF5FileUtility, ONLY: ExportRealVector
 USE HDF5FileUtility, ONLY: ImportRealVector
-USE HDF5FileUtility, ONLY: ExportDOF
 
 IMPLICIT NONE
 
@@ -38,7 +38,9 @@ CHARACTER(*), PARAMETER :: myName = "obj_Import()"
 #endif
 
 TYPE(String) :: dsetname
-LOGICAL(LGT) :: abool
+TYPE(String), ALLOCATABLE :: tempStrs(:)
+INTEGER(I4B) :: ii, tsize
+LOGICAL(LGT) :: isok
 
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &
@@ -49,18 +51,54 @@ CALL AbstractFieldImport( &
   obj=obj, hdf5=hdf5, group=group, fedof=fedof, fedofs=fedofs, &
   geofedof=geofedof, geofedofs=geofedofs)
 
-dsetname = TRIM(group)//"/tSize"
-abool = hdf5%pathExists(dsetname%chars())
-IF (abool) CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%tSize)
+dsetname = TRIM(group)//"/INTR0/dof_tPhysicalVars"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
+                         vals=obj%dof_tPhysicalVars)
 
-dsetname = TRIM(group)//"/dof"
-abool = hdf5%pathExists(dsetname%chars())
-IF (abool) CALL ImportDOF(obj=obj%dof, hdf5=hdf5, group=dsetname%chars())
+dsetname = TRIM(group)//"/INTR0/dof_storageFMT"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
+                         vals=obj%dof_storageFMT)
 
-dsetname = TRIM(group)//"/realVec"
-abool = hdf5%pathExists(dsetname%chars())
-IF (abool) CALL ImportRealVector(obj=obj%realvec, hdf5=hdf5, &
-                                 group=dsetname%chars())
+dsetname = TRIM(group)//"/INTR0/tSize"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
+                         vals=obj%tSize)
+
+dsetname = TRIM(group)//"/INTR1/dof_spaceCompo"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
+                         vals=obj%dof_spaceCompo)
+
+dsetname = TRIM(group)//"/INTR1/dof_timeCompo"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
+                         vals=obj%dof_timeCompo)
+
+dsetname = TRIM(group)//"/INTR1/dof_tNodes"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
+                         vals=obj%dof_tNodes)
+
+! StringR1
+dsetname = TRIM(group)//"/StringR1/dof_names_char"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%Chars(), vals=tempStrs)
+  tsize = SIZE(tempStrs)
+  ALLOCATE (obj%dof_names_char(tSize))
+  DO ii = 1, tsize
+    obj%dof_names_char(ii) = tempStrs(ii)%slice(1, 1)
+    tempStrs(ii) = ""
+  END DO
+  DEALLOCATE (tempStrs)
+END IF
+
+dsetname = TRIM(group)//"/RealVectorR0/realVec"
+isok = hdf5%pathExists(dsetname%chars())
+IF (isok) CALL ImportRealVector(obj=obj%realvec, hdf5=hdf5, &
+                                group=dsetname%chars())
 
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &
@@ -76,8 +114,11 @@ MODULE PROCEDURE obj_Export
 #ifdef DEBUG_VER
 CHARACTER(*), PARAMETER :: myName = "obj_Export()"
 #endif
+LOGICAL(LGT) :: isok
 
 TYPE(String) :: dsetname
+TYPE(String), ALLOCATABLE :: tempStrs(:)
+INTEGER(I4B) :: ii, tsize
 
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &
@@ -86,16 +127,59 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
 
 CALL AbstractFieldExport(obj=obj, hdf5=hdf5, group=group)
 
+! Integer Scalars
+! ---------------
+! dof_tPhysicalVars
+dsetname = TRIM(group)//"/IntR0/dof_tPhysicalVars"
+CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%dof_tPhysicalVars)
+
+! dof_storageFMT
+dsetname = TRIM(group)//"/IntR0/dof_storageFMT"
+CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%dof_storageFMT)
+
 ! tSize
-dsetname = TRIM(group)//"/tSize"
+dsetname = TRIM(group)//"/IntR0/tSize"
 CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%tSize)
 
-! dof
-dsetname = TRIM(group)//"/dof"
-CALL ExportDOF(obj=obj%dof, hdf5=hdf5, group=dsetname%chars())
+! Integer Vectors
+! ---------------
+
+isok = ALLOCATED(obj%dof_spaceCompo)
+IF (isok) THEN
+  dsetname = TRIM(group)//"/IntR1/dof_spaceCompo"
+  CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%dof_spaceCompo)
+END IF
+
+isok = ALLOCATED(obj%dof_timeCompo)
+IF (isok) THEN
+  dsetname = TRIM(group)//"/IntR1/dof_timeCompo"
+  CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%dof_timeCompo)
+END IF
+
+isok = ALLOCATED(obj%dof_tNodes)
+IF (isok) THEN
+  dsetname = TRIM(group)//"/IntR1/dof_tNodes"
+  CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%dof_tNodes)
+END IF
+
+! StringR1
+isok = ALLOCATED(obj%dof_names_char)
+IF (isok) THEN
+  tsize = SIZE(obj%dof_names_char)
+  ALLOCATE (tempStrs(tsize))
+  DO ii = 1, tsize
+    tempStrs(ii) = obj%dof_names_char(ii)
+  END DO
+  dsetname = TRIM(group)//"/StringR1/dof_names_char"
+  CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=tempStrs)
+  DO ii = 1, tsize
+    tempStrs(ii) = ""
+  END DO
+  DEALLOCATE (tempStrs)
+END IF
 
 ! realVec
-dsetname = TRIM(group)//"/realVec"
+dsetname = TRIM(group)//"/RealVectorR0/realVec"
 CALL ExportRealVector(obj=obj%realVec, hdf5=hdf5, group=dsetname%chars())
 
 ! info
@@ -106,7 +190,7 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
 END PROCEDURE obj_Export
 
 !----------------------------------------------------------------------------
-!                                                               Include Error
+!                                                              Include Error
 !----------------------------------------------------------------------------
 
 #include "../../include/errors.F90"

--- a/src/submodules/AbstractNodeField/src/AbstractNodeField_Class@HDFMethods.F90
+++ b/src/submodules/AbstractNodeField/src/AbstractNodeField_Class@HDFMethods.F90
@@ -51,32 +51,32 @@ CALL AbstractFieldImport( &
   obj=obj, hdf5=hdf5, group=group, fedof=fedof, fedofs=fedofs, &
   geofedof=geofedof, geofedofs=geofedofs)
 
-dsetname = TRIM(group)//"/INTR0/dof_tPhysicalVars"
+dsetname = TRIM(group)//"/IntR0/dof_tPhysicalVars"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
                          vals=obj%dof_tPhysicalVars)
 
-dsetname = TRIM(group)//"/INTR0/dof_storageFMT"
+dsetname = TRIM(group)//"/IntR0/dof_storageFMT"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
                          vals=obj%dof_storageFMT)
 
-dsetname = TRIM(group)//"/INTR0/tSize"
+dsetname = TRIM(group)//"/IntR0/tSize"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
                          vals=obj%tSize)
 
-dsetname = TRIM(group)//"/INTR1/dof_spaceCompo"
+dsetname = TRIM(group)//"/IntR1/dof_spaceCompo"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
                          vals=obj%dof_spaceCompo)
 
-dsetname = TRIM(group)//"/INTR1/dof_timeCompo"
+dsetname = TRIM(group)//"/IntR1/dof_timeCompo"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
                          vals=obj%dof_timeCompo)
 
-dsetname = TRIM(group)//"/INTR1/dof_tNodes"
+dsetname = TRIM(group)//"/IntR1/dof_tNodes"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) CALL hdf5%READ(dsetname=dsetname%chars(), &
                          vals=obj%dof_tNodes)

--- a/src/submodules/AbstractNodeField/src/AbstractNodeField_Class@VTKMethods.F90
+++ b/src/submodules/AbstractNodeField/src/AbstractNodeField_Class@VTKMethods.F90
@@ -15,27 +15,23 @@
 ! along with this program.  If not, see <https: //www.gnu.org/licenses/>
 
 SUBMODULE(AbstractNodeField_Class) VTKMethods
-USE BaseType, ONLY: TypeFEVariableScalar, &
-                    TypeFEVariableVector, &
-                    TypeFEVariableSpace, &
-                    TypeFEVariableSpaceTime, &
-                    IntVector_, &
-                    TypeFEVariableOpt
-
-USE Display_Method, ONLY: Display, ToString
-
+USE BaseType, ONLY: TypeFEVariableScalar
+USE BaseType, ONLY: TypeFEVariableVector
+USE BaseType, ONLY: TypeFEVariableSpace
+USE BaseType, ONLY: TypeFEVariableSpaceTime
+USE BaseType, ONLY: IntVector_
+USE BaseType, ONLY: math => TypeMathOpt
+USE BaseType, ONLY: TypeFEVariableOpt
+USE Display_Method, ONLY: Display
+USE Display_Method, ONLY: ToString
 USE AbstractMesh_Class, ONLY: AbstractMesh_
-
 USE String_Class, ONLY: String
-
-USE FEVariable_Method, ONLY: OPERATOR(.RANK.), &
-                             OPERATOR(.vartype.), &
-                             FEVariable_Get => Get, &
-                             FEVariable_Deallocate => DEALLOCATE
-
-USE IntVector_Method, ONLY: IntVector_Initiate => Initiate, &
-                            ASSIGNMENT(=)
-
+USE FEVariable_Method, ONLY: OPERATOR(.RANK.)
+USE FEVariable_Method, ONLY: OPERATOR(.vartype.)
+USE FEVariable_Method, ONLY: FEVariable_Get => Get
+USE FEVariable_Method, ONLY: FEVariable_Deallocate => DEALLOCATE
+USE IntVector_Method, ONLY: IntVector_Initiate => Initiate
+USE IntVector_Method, ONLY: ASSIGNMENT(=)
 IMPLICIT NONE
 
 CONTAINS
@@ -74,7 +70,6 @@ MODULE PROCEDURE obj_WriteData_vtk1
 CHARACTER(*), PARAMETER :: myname = "obj_WriteData_vtk1()"
 #endif
 
-LOGICAL(LGT), PARAMETER :: yes = .TRUE., no = .FALSE.
 CLASS(AbstractMesh_), POINTER :: meshptr
 TYPE(String) :: location, action
 
@@ -88,7 +83,8 @@ CALL Writedata_vtk1_CheckError(obj=obj, vtk=vtk)
 #endif
 
 meshptr => obj%fedof%GetMeshPointer()
-CALL meshptr%ExportToVTK(vtk=vtk, openTag=yes, content=yes, closeTag=no)
+CALL meshptr%ExportToVTK(vtk=vtk, openTag=math%yes, content=math%yes, &
+                         closeTag=math%no)
 location = String('node')
 action = String('open')
 CALL vtk%WriteDataArray(location=location, action=action)
@@ -112,7 +108,7 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
 END PROCEDURE obj_WriteData_vtk1
 
 !----------------------------------------------------------------------------
-!                                                             WriteData
+!                                                                  WriteData
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_WriteData_vtk2
@@ -120,8 +116,8 @@ MODULE PROCEDURE obj_WriteData_vtk2
 CHARACTER(*), PARAMETER :: myName = "obj_WriteData_vtk2()"
 #endif
 
-INTEGER(I4B), PARAMETER :: maxObjSize = 24 ! maximum size of obj
-LOGICAL(LGT), PARAMETER :: no = .FALSE., yes = .TRUE.
+INTEGER(I4B), PARAMETER :: maxObjSize = 24
+! maximum size of obj
 
 LOGICAL(LGT) :: isOK
 INTEGER(I4B), ALLOCATABLE :: nptrs(:)
@@ -165,11 +161,13 @@ DO iobj = 1, tfield
 
   isok = obj0%IsInitiated()
   CALL AssertError1(isok, myName, &
-            'AbstractNodeField_::obj('//ToString(iobj)//') is not Initiated.')
+                    'AbstractNodeField_::obj('// &
+                    ToString(iobj)//') is not Initiated.')
 
   isok = ASSOCIATED(obj0%fedof)
   CALL AssertError1(isok, myName, &
-      'AbstractNodeField_::obj('//ToString(iobj)//')%fedof is not associated')
+                    'AbstractNodeField_::obj('// &
+                    ToString(iobj)//')%fedof is not associated')
 END DO
 #endif
 
@@ -217,7 +215,8 @@ ALLOCATE (xij(3, tnodes))
 CALL meshptr%GetNodeCoord(nodeCoord=xij, nrow=nrow, ncol=ncol)
 
 CALL meshptr%ExportToVTK(vtk=vtk, nodeCoord=xij, &
-                         openTag=yes, content=yes, closeTag=no)
+                         openTag=math%yes, content=math%yes, &
+                         closeTag=math%no)
 
 location = String('node')
 action = String('open')
@@ -234,7 +233,7 @@ DO iobj = 1, tfield
   CALL ExportFieldToVTK( &
     obj=obj0, vtk=vtk, nptrs=nptrs, tPhysicalVars=tPhysicalVars(iobj), &
     dofNames=dofNames(tsize + 1:aint), spaceCompo=spaceCompo(iobj)%val, &
-    timeCompo=timeCompo(iobj)%val, islocal=no)
+    timeCompo=timeCompo(iobj)%val, islocal=math%no)
 
   tsize = aint
 END DO
@@ -316,8 +315,9 @@ SUBROUTINE ExportFieldToVTK(obj, vtk, nptrs, tPhysicalVars, dofNames, &
         r2 = FEVariable_Get(fevar, TypeFEVariableScalar, &
                             TypeFEVariableSpaceTime)
         DO itime = 1, timeCompo(ivar)
-          CALL vtk%WriteDataArray(name=String(name//"_t"//ToString(itime)), &
-                          x=r2(itime, :), numberOfComponents=spaceCompo(ivar))
+          CALL vtk%WriteDataArray( &
+            name=String(name//"_t"//ToString(itime)), &
+            x=r2(itime, :), numberOfComponents=spaceCompo(ivar))
         END DO
       END IF
 
@@ -337,15 +337,17 @@ SUBROUTINE ExportFieldToVTK(obj, vtk, nptrs, tPhysicalVars, dofNames, &
                             TypeFEVariableSpaceTime)
 
         DO itime = 1, timeCompo(ivar)
-          CALL vtk%WriteDataArray(name=String(name//"_t"//ToString(itime)), &
-                       x=r3(:, :, itime), numberOfComponents=spaceCompo(ivar))
+          CALL vtk%WriteDataArray( &
+            name=String(name//"_t"//ToString(itime)), &
+            x=r3(:, :, itime), numberOfComponents=spaceCompo(ivar))
         END DO
 
       END IF
 
-#ifdef DEBUG_VER
     CASE DEFAULT
-      CALL AssertError1(.FALSE., myName, 'No case found for fevar')
+
+#ifdef DEBUG_VER
+      CALL AssertError1(math%no, myName, 'No case found for fevar')
 #endif
 
     END SELECT

--- a/src/submodules/H1FE/src/TriangleH1/TriangleH1FE_Class@Methods.F90
+++ b/src/submodules/H1FE/src/TriangleH1/TriangleH1FE_Class@Methods.F90
@@ -203,7 +203,9 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
                         '[START] ')
 #endif
 
-alpha0 = 0.0_DFP; beta0 = 0.0_DFP; lambda0 = 0.5_DFP
+alpha0 = 0.0_DFP
+beta0 = 0.0_DFP
+lambda0 = 0.5_DFP
 
 IF (PRESENT(alpha)) alpha0 = alpha(1)
 IF (PRESENT(beta)) beta0 = beta(1)

--- a/src/submodules/HDF5File/src/HDF5FileUtility@Methods.F90
+++ b/src/submodules/HDF5File/src/HDF5FileUtility@Methods.F90
@@ -641,6 +641,189 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
 END PROCEDURE ImportIntVector
 
 !----------------------------------------------------------------------------
+!                                                        HDF5WriteCharVector
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE HDF5WriteCharVector
+#ifdef DEBUG_VER
+CHARACTER(*), PARAMETER :: myName = "HD5WriteCharVector()"
+#endif
+TYPE(String) :: dsetname
+INTEGER(I4B) :: tsize, ii
+TYPE(String), ALLOCATABLE :: tempstr(:)
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[START] ')
+#endif
+
+tsize = SIZE(VALUE)
+ALLOCATE (tempstr(tsize))
+
+DO ii = 1, tsize
+  tempstr(ii) = TRIM(VALUE(ii))
+END DO
+
+!> tDimension
+dsetname = TRIM(group)//"/"//TRIM(fieldname)
+CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=tempstr)
+
+DO ii = 1, tsize
+  tempstr(ii) = ""
+END DO
+
+DEALLOCATE (tempstr)
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[END] ')
+#endif
+END PROCEDURE HDF5WriteCharVector
+
+!----------------------------------------------------------------------------
+!                                                        HDF5WriteCharMatrix
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE HDF5WriteCharMatrix
+#ifdef DEBUG_VER
+CHARACTER(*), PARAMETER :: myName = "HD5WriteCharMatrix()"
+#endif
+TYPE(String) :: dsetname
+INTEGER(I4B) :: nrow, ncol, ii, jj
+TYPE(String), ALLOCATABLE :: tempstr(:, :)
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[START] ')
+#endif
+
+nrow = SIZE(VALUE, 1)
+ncol = SIZE(VALUE, 2)
+ALLOCATE (tempstr(nrow, ncol))
+
+DO jj = 1, ncol
+  DO ii = 1, nrow
+    tempstr(ii, jj) = TRIM(VALUE(ii, jj))
+  END DO
+END DO
+
+dsetname = TRIM(group)//"/"//TRIM(fieldname)
+CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=tempstr)
+
+DO jj = 1, ncol
+  DO ii = 1, nrow
+    tempstr(ii, jj) = ""
+  END DO
+END DO
+
+DEALLOCATE (tempstr)
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[END] ')
+#endif
+END PROCEDURE HDF5WriteCharMatrix
+
+!----------------------------------------------------------------------------
+!                                                        HDF5ReadCharVector
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE HDF5ReadCharVector
+#ifdef DEBUG_VER
+CHARACTER(*), PARAMETER :: myName = "HD5ReadCharVector()"
+#endif
+TYPE(String) :: dsetname
+INTEGER(I4B) :: tsize, ii
+TYPE(String), ALLOCATABLE :: tempstr(:)
+CHARACTER(1) :: asource
+LOGICAL(LGT) :: isok
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[START] ')
+#endif
+
+dsetname = group//"/"//fieldname
+isok = hdf5%pathExists(dsetname%Chars())
+
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%Chars(), vals=tempstr)
+  IF (ALLOCATED(VALUE)) DEALLOCATE (VALUE)
+
+  tsize = SIZE(tempstr)
+  ALLOCATE (VALUE(tsize), source=asource)
+
+  DO ii = 1, tsize
+    VALUE(ii) = tempstr(ii)%slice(1, 1)
+  END DO
+
+  DO ii = 1, tsize
+    tempstr(ii) = ""
+  END DO
+
+  DEALLOCATE (tempstr)
+  dsetname = ""
+END IF
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[END] ')
+#endif
+END PROCEDURE HDF5ReadCharVector
+
+!----------------------------------------------------------------------------
+!                                                        HDF5ReadCharMatrix
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE HDF5ReadCharMatrix
+#ifdef DEBUG_VER
+CHARACTER(*), PARAMETER :: myName = "HD5ReadCharMatrix()"
+#endif
+TYPE(String) :: dsetname
+INTEGER(I4B) :: nrow, ncol, ii, jj
+TYPE(String), ALLOCATABLE :: tempstr(:, :)
+CHARACTER(1) :: asource
+LOGICAL(LGT) :: isok
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[START] ')
+#endif
+
+dsetname = group//"/"//fieldname
+isok = hdf5%pathExists(dsetname%Chars())
+
+IF (isok) THEN
+  CALL hdf5%READ(dsetname=dsetname%Chars(), vals=tempstr)
+  IF (ALLOCATED(VALUE)) DEALLOCATE (VALUE)
+
+  nrow = SIZE(tempstr, 1)
+  ncol = SIZE(tempstr, 2)
+  ALLOCATE (VALUE(nrow, ncol), source=asource)
+
+  DO jj = 1, ncol
+    DO ii = 1, nrow
+      VALUE(ii, jj) = tempstr(ii, jj)%slice(1, 1)
+    END DO
+  END DO
+
+  DO jj = 1, ncol
+    DO ii = 1, nrow
+      tempstr(ii, jj) = ""
+    END DO
+  END DO
+
+  DEALLOCATE (tempstr)
+  dsetname = ""
+END IF
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[END] ')
+#endif
+END PROCEDURE HDF5ReadCharMatrix
+
+!----------------------------------------------------------------------------
 !
 !----------------------------------------------------------------------------
 

--- a/src/submodules/HDF5File/src/HDF5FileUtility@Methods.F90
+++ b/src/submodules/HDF5File/src/HDF5FileUtility@Methods.F90
@@ -272,22 +272,30 @@ MODULE PROCEDURE ExportDOF
 CHARACTER(*), PARAMETER :: myName = "ExportDOF()"
 #endif
 TYPE(String) :: dsetname
+LOGICAL(LGT) :: isok
 
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &
                         '[START] ')
 #endif
 
-dsetname = TRIM(group)//"/storageFMT"
+dsetname = TRIM(group)//"/IntR0/storageFMT"
 CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%storageFMT)
 
-IF (ALLOCATED(obj%map)) THEN
-  dsetname = TRIM(group)//"/map"
+dsetname = TRIM(group)//"/IntR0/mapRow"
+CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%mapRow)
+
+dsetname = TRIM(group)//"/IntR0/valMapSize"
+CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%valMapSize)
+
+isok = ALLOCATED(obj%map)
+IF (isok) THEN
+  dsetname = TRIM(group)//"/IntR2/map"
   CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%map)
 END IF
 
 IF (ALLOCATED(obj%valMap)) THEN
-  dsetname = TRIM(group)//"/valMap"
+  dsetname = TRIM(group)//"/IntR1/valMap"
   CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%valMap)
 END IF
 
@@ -543,11 +551,11 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
 #endif
 
 !> tDimension
-dsetname = TRIM(group)//"/tDimension"
+dsetname = TRIM(group)//"/IntR0/tDimension"
 CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%tDimension)
 
-!> Val
-dsetname = TRIM(group)//"/Val"
+!> val
+dsetname = TRIM(group)//"/RealR1/val"
 CALL hdf5%WRITE(dsetname=dsetname%chars(), vals=obj%Val)
 
 #ifdef DEBUG_VER
@@ -574,7 +582,7 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
 dsetname = TRIM(group)//"/tDimension"
 CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%tDimension)
 
-dsetname = TRIM(group)//"/Val"
+dsetname = TRIM(group)//"/val"
 CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%Val)
 
 #ifdef DEBUG_VER

--- a/src/submodules/HDF5File/src/HDF5FileUtility@Methods.F90
+++ b/src/submodules/HDF5File/src/HDF5FileUtility@Methods.F90
@@ -322,15 +322,21 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
                         '[START] ')
 #endif
 
-dsetname = TRIM(group)//"/storageFMT"
+dsetname = TRIM(group)//"/IntR0/storageFMT"
 CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%storageFMT)
 
-dsetname = TRIM(group)//"/map"
+dsetname = TRIM(group)//"/IntR0/mapRow"
+CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%mapRow)
+
+dsetname = TRIM(group)//"/IntR0/valMapSize"
+CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%valMapSize)
+
+dsetname = TRIM(group)//"/IntR2/map"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) &
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%map)
 
-dsetname = TRIM(group)//"/valMap"
+dsetname = TRIM(group)//"/IntR1/valMap"
 isok = hdf5%pathExists(dsetname%chars())
 IF (isok) &
   CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%valMap)
@@ -579,10 +585,10 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
                         '[START] ')
 #endif
 
-dsetname = TRIM(group)//"/tDimension"
+dsetname = TRIM(group)//"/IntR0/tDimension"
 CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%tDimension)
 
-dsetname = TRIM(group)//"/val"
+dsetname = TRIM(group)//"/RealR1/val"
 CALL hdf5%READ(dsetname=dsetname%chars(), vals=obj%Val)
 
 #ifdef DEBUG_VER

--- a/src/submodules/HDF5File/src/HDF5File_Class@WriteString.F90
+++ b/src/submodules/HDF5File/src/HDF5File_Class@WriteString.F90
@@ -25,39 +25,39 @@ CONTAINS
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE hdf5_write_st0
-  CHARACTER( LEN=LEN_TRIM(vals) ) :: valss
-  CHARACTER( LEN=LEN(dsetname)+1 ) :: path
-  INTEGER( HSIZE_T ), DIMENSION( 1 ) :: ldims,gdims,offset,cnt
-  INTEGER( I4B ), PARAMETER :: rank=0
-  INTEGER( HID_T ) :: mem,dspace_id,dset_id,gspace_id,plist_id
+CHARACTER(LEN=LEN_TRIM(vals)) :: valss
+CHARACTER(LEN=LEN(dsetname) + 1) :: path
+INTEGER(HSIZE_T), DIMENSION(1) :: ldims, gdims, offset, cnt
+INTEGER(I4B), PARAMETER :: rank = 0
+INTEGER(HID_T) :: mem, dspace_id, dset_id, gspace_id, plist_id
 
-  path=dsetname
-  valss=vals%chars()
-  ! stash offset
-  offset(1)=0
-  IF(PRESENT(offset_in)) offset=offset_in
+path = dsetname
+valss = vals%chars()
+! stash offset
+offset(1) = 0
+IF (PRESENT(offset_in)) offset = offset_in
 
-  ! Determine the dimensions for the dataspace
-  ldims=1
+! Determine the dimensions for the dataspace
+ldims = 1
 
-  ! Store the dimensions from global if present
-  IF(PRESENT(gdims_in)) THEN
-    gdims=gdims_in
-  ELSE
-    gdims=ldims
-  ENDIF
-  cnt=gdims
-  IF(PRESENT(cnt_in)) cnt=cnt_in
+! Store the dimensions from global if present
+IF (PRESENT(gdims_in)) THEN
+  gdims = gdims_in
+ELSE
+  gdims = ldims
+END IF
+cnt = gdims
+IF (PRESENT(cnt_in)) cnt = cnt_in
 
-  CALL h5tcopy_f( H5T_NATIVE_CHARACTER, mem, ierr )
-  CALL h5tset_strpad_f( mem, 0, ierr )
-  CALL h5tset_size_f( mem, INT( LEN_TRIM(vals), Real64), ierr )
-  CALL preWrite( obj, rank, gdims, ldims, path, mem, dset_id, dspace_id, &
-    & gspace_id, plist_id, ierr, cnt, offset )
-  IF(ierr == 0) &
-    & CALL h5dwrite_f(dset_id,mem,valss,gdims,ierr,dspace_id,gspace_id,plist_id)
-  CALL postWrite(obj,ierr,dset_id,dspace_id,gspace_id,plist_id)
-  CALL h5tclose_f(mem,ierr)
+CALL h5tcopy_f(H5T_NATIVE_CHARACTER, mem, ierr)
+CALL h5tset_strpad_f(mem, 0, ierr)
+CALL h5tset_size_f(mem, INT(LEN_TRIM(vals), REAL64), ierr)
+CALL preWrite(obj, rank, gdims, ldims, path, mem, dset_id, dspace_id, &
+              gspace_id, plist_id, ierr, cnt, offset)
+IF (ierr == 0) &
+  CALL h5dwrite_f(dset_id,mem,valss,gdims,ierr,dspace_id,gspace_id,plist_id)
+CALL postWrite(obj, ierr, dset_id, dspace_id, gspace_id, plist_id)
+CALL h5tclose_f(mem, ierr)
 END PROCEDURE hdf5_write_st0
 
 !----------------------------------------------------------------------------
@@ -65,44 +65,44 @@ END PROCEDURE hdf5_write_st0
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE hdf5_write_st1
-  CHARACTER( LEN=length_max ) :: valss( SIZE( vals ) )
-  CHARACTER( LEN=LEN(dsetname)+1 ) :: path
-  INTEGER( I4B ) :: j
-  INTEGER( HSIZE_T ), DIMENSION( 1 ) :: ldims, gdims, offset, cnt
-  INTEGER( I4B ), PARAMETER :: rank=1
-  INTEGER( HID_T ) :: mem, dspace_id, dset_id, gspace_id, plist_id
+CHARACTER(LEN=length_max) :: valss(SIZE(vals))
+CHARACTER(LEN=LEN(dsetname) + 1) :: path
+INTEGER(I4B) :: j
+INTEGER(HSIZE_T), DIMENSION(1) :: ldims, gdims, offset, cnt
+INTEGER(I4B), PARAMETER :: rank = 1
+INTEGER(HID_T) :: mem, dspace_id, dset_id, gspace_id, plist_id
 
-  path=dsetname
-  ! Fill character array
-  DO j=1,SIZE(vals,DIM=1)
-    valss(j)=vals(j)%chars()
-  ENDDO
+path = dsetname
+! Fill character array
+DO j = 1, SIZE(vals, DIM=1)
+  valss(j) = vals(j)%chars()
+END DO
 
-  ! stash offset
-  offset(1)=0
-  IF(PRESENT(offset_in)) offset=offset_in
+! stash offset
+offset(1) = 0
+IF (PRESENT(offset_in)) offset = offset_in
 
-  ! Determine the dimensions for the dataspace
-  ldims=SHAPE(vals)
+! Determine the dimensions for the dataspace
+ldims = SHAPE(vals)
 
-  ! Store the dimensions from global if present
-  IF(PRESENT(gdims_in)) THEN
-    gdims=gdims_in
-  ELSE
-    gdims=ldims
-  ENDIF
-  cnt=gdims
-  IF(PRESENT(cnt_in)) cnt=cnt_in
+! Store the dimensions from global if present
+IF (PRESENT(gdims_in)) THEN
+  gdims = gdims_in
+ELSE
+  gdims = ldims
+END IF
+cnt = gdims
+IF (PRESENT(cnt_in)) cnt = cnt_in
 
-  CALL h5tcopy_f(H5T_NATIVE_CHARACTER,mem,ierr)
-  CALL h5tset_strpad_f(mem,0,ierr)
-  CALL h5tset_size_f(mem,INT(length_max,Real64),ierr)
-  CALL preWrite(obj,rank,gdims,ldims,path,mem,dset_id,dspace_id, &
-    & gspace_id,plist_id,ierr,cnt,offset)
-  IF(ierr == 0) &
-    CALL h5dwrite_f(dset_id,mem,valss,gdims,ierr,dspace_id,gspace_id,plist_id)
-  CALL postWrite(obj,ierr,dset_id,dspace_id,gspace_id,plist_id)
-  CALL h5tclose_f(mem,ierr)
+CALL h5tcopy_f(H5T_NATIVE_CHARACTER, mem, ierr)
+CALL h5tset_strpad_f(mem, 0, ierr)
+CALL h5tset_size_f(mem, INT(length_max, REAL64), ierr)
+CALL preWrite(obj, rank, gdims, ldims, path, mem, dset_id, dspace_id, &
+  & gspace_id, plist_id, ierr, cnt, offset)
+IF (ierr == 0) &
+  CALL h5dwrite_f(dset_id,mem,valss,gdims,ierr,dspace_id,gspace_id,plist_id)
+CALL postWrite(obj, ierr, dset_id, dspace_id, gspace_id, plist_id)
+CALL h5tclose_f(mem, ierr)
 END PROCEDURE hdf5_write_st1
 
 !----------------------------------------------------------------------------
@@ -110,14 +110,14 @@ END PROCEDURE hdf5_write_st1
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE hdf5_write_st1_helper
-  INTEGER( I4B ) :: length_max, i, local_gdims(1)
-  length_max=0
-  DO i=1,SIZE(vals)
-    length_max=MAX(LEN_TRIM(vals(i)),length_max)
-  ENDDO
-  local_gdims(1:)=SHAPE(vals)
-  IF(PRESENT(gdims_in)) local_gdims(1)=gdims_in(1)
-  CALL hdf5_write_st1(obj,dsetname,vals,length_max,local_gdims)
+INTEGER(I4B) :: length_max, i, local_gdims(1)
+length_max = 0
+DO i = 1, SIZE(vals)
+  length_max = MAX(LEN_TRIM(vals(i)), length_max)
+END DO
+local_gdims(1:) = SHAPE(vals)
+IF (PRESENT(gdims_in)) local_gdims(1) = gdims_in(1)
+CALL hdf5_write_st1(obj, dsetname, vals, length_max, local_gdims)
 END PROCEDURE hdf5_write_st1_helper
 
 !----------------------------------------------------------------------------
@@ -125,20 +125,20 @@ END PROCEDURE hdf5_write_st1_helper
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE hdf5_write_st2_helper
-  INTEGER( I4B ) :: length_max, i, j, local_gdims(1)
+INTEGER(I4B) :: length_max, i, j, local_gdims(1)
 
-  length_max=0
-  DO j=1,SIZE(vals,1)
-    DO i=1,SIZE(vals,2)
-      length_max=MAX(LEN_TRIM(vals(j,i)),length_max)
-    END DO
+length_max = 0
+DO j = 1, SIZE(vals, 1)
+  DO i = 1, SIZE(vals, 2)
+    length_max = MAX(LEN_TRIM(vals(j, i)), length_max)
   END DO
+END DO
 
-  IF(PRESENT(gdims_in)) THEN
-    CALL hdf5_write_st2(obj, dsetname,vals,length_max,gdims_in)
-  ELSE
-    CALL hdf5_write_st2(obj, dsetname,vals,length_max)
-  ENDIF
+IF (PRESENT(gdims_in)) THEN
+  CALL hdf5_write_st2(obj, dsetname, vals, length_max, gdims_in)
+ELSE
+  CALL hdf5_write_st2(obj, dsetname, vals, length_max)
+END IF
 END PROCEDURE hdf5_write_st2_helper
 
 !----------------------------------------------------------------------------
@@ -146,46 +146,46 @@ END PROCEDURE hdf5_write_st2_helper
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE hdf5_write_st2
-  CHARACTER( LEN=length_max ) :: valss(SIZE(vals,1),SIZE(vals,2))
-  CHARACTER( LEN=LEN(dsetname)+1 ) :: path
-  INTEGER( I4B ) :: j,k
-  INTEGER( HSIZE_T ), DIMENSION( 2 ) :: gdims,ldims,offset,cnt
-  INTEGER( I4B ), PARAMETER :: rank=2
-  INTEGER( HID_T ) :: mem,dspace_id,dset_id,gspace_id,plist_id
+CHARACTER(LEN=length_max) :: valss(SIZE(vals, 1), SIZE(vals, 2))
+CHARACTER(LEN=LEN(dsetname) + 1) :: path
+INTEGER(I4B) :: j, k
+INTEGER(HSIZE_T), DIMENSION(2) :: gdims, ldims, offset, cnt
+INTEGER(I4B), PARAMETER :: rank = 2
+INTEGER(HID_T) :: mem, dspace_id, dset_id, gspace_id, plist_id
 
-  path=dsetname
-  DO k = 1, SIZE(vals,2)
-    DO j = 1, SIZE(vals,1)
-      valss(j,k)=vals(j,k)%chars()
-    END DO
+path = dsetname
+DO k = 1, SIZE(vals, 2)
+  DO j = 1, SIZE(vals, 1)
+    valss(j, k) = vals(j, k)%chars()
   END DO
+END DO
 
-  ! stash offset
-  offset(1)=LBOUND(vals,1)-1
-  offset(2)=LBOUND(vals,2)-1
-  IF(PRESENT(offset_in)) offset=offset_in
+! stash offset
+offset(1) = LBOUND(vals, 1) - 1
+offset(2) = LBOUND(vals, 2) - 1
+IF (PRESENT(offset_in)) offset = offset_in
 
-  ! Determine the dimensions for the dataspace
-  ldims=SHAPE(vals)
+! Determine the dimensions for the dataspace
+ldims = SHAPE(vals)
 
-  ! Store the dimensions from global if present
-  IF(PRESENT(gdims_in)) THEN
-    gdims=gdims_in
-  ELSE
-    gdims=ldims
-  ENDIF
-  cnt=gdims
-  IF(PRESENT(cnt_in)) cnt=cnt_in
+! Store the dimensions from global if present
+IF (PRESENT(gdims_in)) THEN
+  gdims = gdims_in
+ELSE
+  gdims = ldims
+END IF
+cnt = gdims
+IF (PRESENT(cnt_in)) cnt = cnt_in
 
-  CALL h5tcopy_f(H5T_NATIVE_CHARACTER,mem,ierr)
-  CALL h5tset_strpad_f(mem,0,ierr)
-  CALL h5tset_size_f(mem,INT(length_max,Real64),ierr)
-  CALL preWrite(obj,rank,gdims,ldims,path,mem,dset_id,dspace_id, &
-    & gspace_id,plist_id,ierr,cnt,offset)
-  IF(ierr == 0) &
-    CALL h5dwrite_f(dset_id,mem,valss,gdims,ierr,dspace_id,gspace_id,plist_id)
-  CALL postWrite(obj,ierr,dset_id,dspace_id,gspace_id,plist_id)
-  CALL h5tclose_f(mem,ierr)
+CALL h5tcopy_f(H5T_NATIVE_CHARACTER, mem, ierr)
+CALL h5tset_strpad_f(mem, 0, ierr)
+CALL h5tset_size_f(mem, INT(length_max, REAL64), ierr)
+CALL preWrite(obj, rank, gdims, ldims, path, mem, dset_id, dspace_id, &
+  & gspace_id, plist_id, ierr, cnt, offset)
+IF (ierr == 0) &
+  CALL h5dwrite_f(dset_id,mem,valss,gdims,ierr,dspace_id,gspace_id,plist_id)
+CALL postWrite(obj, ierr, dset_id, dspace_id, gspace_id, plist_id)
+CALL h5tclose_f(mem, ierr)
 END PROCEDURE hdf5_write_st2
 
 !----------------------------------------------------------------------------
@@ -193,22 +193,22 @@ END PROCEDURE hdf5_write_st2
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE hdf5_write_st3_helper
-  INTEGER( I4B ) :: length_max, i, j, local_gdims(1), k
+INTEGER(I4B) :: length_max, i, j, local_gdims(1), k
 
-  length_max=0
-  DO k=1,SIZE(vals, 3)
-    DO j=1,SIZE(vals, 2)
-      DO i=1,SIZE(vals, 1)
-        length_max=MAX(LEN_TRIM(vals(i,j,k)),length_max)
-      END DO
+length_max = 0
+DO k = 1, SIZE(vals, 3)
+  DO j = 1, SIZE(vals, 2)
+    DO i = 1, SIZE(vals, 1)
+      length_max = MAX(LEN_TRIM(vals(i, j, k)), length_max)
     END DO
   END DO
+END DO
 
-  IF(PRESENT(gdims_in)) THEN
-    CALL hdf5_write_st3(obj, dsetname,vals,length_max,gdims_in)
-  ELSE
-    CALL hdf5_write_st3(obj, dsetname,vals,length_max)
-  ENDIF
+IF (PRESENT(gdims_in)) THEN
+  CALL hdf5_write_st3(obj, dsetname, vals, length_max, gdims_in)
+ELSE
+  CALL hdf5_write_st3(obj, dsetname, vals, length_max)
+END IF
 END PROCEDURE hdf5_write_st3_helper
 
 !----------------------------------------------------------------------------
@@ -216,49 +216,49 @@ END PROCEDURE hdf5_write_st3_helper
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE hdf5_write_st3
-  CHARACTER( LEN=length_max ) :: valss( SIZE(vals,1),SIZE(vals,2), &
-    & SIZE(vals,3) )
-  CHARACTER( LEN=LEN(dsetname)+1 ) :: path
-  INTEGER( I4B ) :: i,j,k
-  INTEGER( HSIZE_T ), DIMENSION( 3 ) :: gdims,ldims,offset,cnt
-  INTEGER( I4B ), PARAMETER :: rank=3
-  INTEGER( HID_T ) :: mem,dspace_id,dset_id,gspace_id,plist_id
+CHARACTER(LEN=length_max) :: valss(SIZE(vals, 1), SIZE(vals, 2), &
+  & SIZE(vals, 3))
+CHARACTER(LEN=LEN(dsetname) + 1) :: path
+INTEGER(I4B) :: i, j, k
+INTEGER(HSIZE_T), DIMENSION(3) :: gdims, ldims, offset, cnt
+INTEGER(I4B), PARAMETER :: rank = 3
+INTEGER(HID_T) :: mem, dspace_id, dset_id, gspace_id, plist_id
 
-  path=dsetname
-  DO i = 1, SIZE(vals, 3)
-    DO k = 1, SIZE(vals, 2)
-      DO j = 1, SIZE(vals, 1)
-        valss(j,k,i)=vals(j,k,i)%chars()
-      END DO
+path = dsetname
+DO i = 1, SIZE(vals, 3)
+  DO k = 1, SIZE(vals, 2)
+    DO j = 1, SIZE(vals, 1)
+      valss(j, k, i) = vals(j, k, i)%chars()
     END DO
   END DO
+END DO
 
-  ! stash offset
-  offset( 1 ) = LBOUND( vals, 1 ) - 1
-  offset( 2 ) = LBOUND( vals, 2 ) - 1
-  offset( 3 ) = LBOUND( vals, 3 ) - 1
-  IF( PRESENT( offset_in ) ) offset = offset_in
+! stash offset
+offset(1) = LBOUND(vals, 1) - 1
+offset(2) = LBOUND(vals, 2) - 1
+offset(3) = LBOUND(vals, 3) - 1
+IF (PRESENT(offset_in)) offset = offset_in
 
-  ! Determine the dimensions for the dataspace
-  ldims=SHAPE(vals)
+! Determine the dimensions for the dataspace
+ldims = SHAPE(vals)
 
-  ! Store the dimensions from global if present
-  IF( PRESENT( gdims_in ) ) THEN
-    gdims = gdims_in
-  ELSE
-    gdims = ldims
-  ENDIF
-  cnt = gdims
-  IF( PRESENT( cnt_in ) ) cnt = cnt_in
-  CALL h5tcopy_f(H5T_NATIVE_CHARACTER,mem,ierr)
-  CALL h5tset_strpad_f(mem,0,ierr)
-  CALL h5tset_size_f(mem,INT(length_max,Real64),ierr)
-  CALL preWrite(obj,rank,gdims,ldims,path,mem,dset_id,dspace_id, &
-    & gspace_id,plist_id,ierr,cnt,offset)
-  IF(ierr == 0) &
-    CALL h5dwrite_f(dset_id,mem,valss,gdims,ierr,dspace_id,gspace_id,plist_id)
-  CALL postWrite(obj,ierr,dset_id,dspace_id,gspace_id,plist_id)
-  CALL h5tclose_f(mem,ierr)
+! Store the dimensions from global if present
+IF (PRESENT(gdims_in)) THEN
+  gdims = gdims_in
+ELSE
+  gdims = ldims
+END IF
+cnt = gdims
+IF (PRESENT(cnt_in)) cnt = cnt_in
+CALL h5tcopy_f(H5T_NATIVE_CHARACTER, mem, ierr)
+CALL h5tset_strpad_f(mem, 0, ierr)
+CALL h5tset_size_f(mem, INT(length_max, REAL64), ierr)
+CALL preWrite(obj, rank, gdims, ldims, path, mem, dset_id, dspace_id, &
+  & gspace_id, plist_id, ierr, cnt, offset)
+IF (ierr == 0) &
+  CALL h5dwrite_f(dset_id,mem,valss,gdims,ierr,dspace_id,gspace_id,plist_id)
+CALL postWrite(obj, ierr, dset_id, dspace_id, gspace_id, plist_id)
+CALL h5tclose_f(mem, ierr)
 END PROCEDURE hdf5_write_st3
 
 !----------------------------------------------------------------------------
@@ -266,31 +266,31 @@ END PROCEDURE hdf5_write_st3
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE hdf5_write_c1
-  CHARACTER( LEN=LEN(dsetname) + 1 ) :: path
-  INTEGER( HSIZE_T ), DIMENSION( 1 ) :: ldims,offset,gdims,cnt
-  INTEGER( I4B ), PARAMETER :: rank=1
-  INTEGER( HID_T ) :: mem,dspace_id,dset_id,gspace_id,plist_id
-  INTEGER( I4B ) :: error
-  ! stash offset
-  offset(1)=1
-  IF(PRESENT(offset_in)) offset=offset_in
-  path=dsetname
-  ! Determine the dimensions for the dataspace
-  ldims(1)=LEN(vals)
-  ! Store the dimensions from global if present
-  IF(PRESENT(gdims_in)) THEN
-    gdims(1)=gdims_in
-  ELSE
-    gdims(1)=ldims(1)
-  ENDIF
-  cnt=gdims
-  IF(PRESENT(cnt_in)) cnt=cnt_in
-  mem=H5T_NATIVE_CHARACTER
-  CALL preWrite(obj,rank,gdims,ldims,path,mem,dset_id,dspace_id, &
-      gspace_id,plist_id,error,cnt,offset)
-  IF(error == 0) &
-      CALL h5dwrite_f(dset_id,mem,vals,gdims,error,dspace_id,gspace_id,plist_id)
-  CALL postWrite(obj,error,dset_id,dspace_id,gspace_id,plist_id)
+CHARACTER(LEN=LEN(dsetname) + 1) :: path
+INTEGER(HSIZE_T), DIMENSION(1) :: ldims, offset, gdims, cnt
+INTEGER(I4B), PARAMETER :: rank = 1
+INTEGER(HID_T) :: mem, dspace_id, dset_id, gspace_id, plist_id
+INTEGER(I4B) :: error
+! stash offset
+offset(1) = 1
+IF (PRESENT(offset_in)) offset = offset_in
+path = dsetname
+! Determine the dimensions for the dataspace
+ldims(1) = LEN(vals)
+! Store the dimensions from global if present
+IF (PRESENT(gdims_in)) THEN
+  gdims(1) = gdims_in
+ELSE
+  gdims(1) = ldims(1)
+END IF
+cnt = gdims
+IF (PRESENT(cnt_in)) cnt = cnt_in
+mem = H5T_NATIVE_CHARACTER
+CALL preWrite(obj, rank, gdims, ldims, path, mem, dset_id, dspace_id, &
+              gspace_id, plist_id, error, cnt, offset)
+IF (error == 0) &
+  CALL h5dwrite_f(dset_id,mem,vals,gdims,error,dspace_id,gspace_id,plist_id)
+CALL postWrite(obj, error, dset_id, dspace_id, gspace_id, plist_id)
 END PROCEDURE hdf5_write_c1
 
 !----------------------------------------------------------------------------

--- a/src/submodules/ScalarField/src/ScalarField_Class@GetMethods.F90
+++ b/src/submodules/ScalarField/src/ScalarField_Class@GetMethods.F90
@@ -34,7 +34,10 @@ USE FEVariable_Method, ONLY: QuadratureVariable
 USE MeshField_Class, ONLY: ScalarMeshFieldInitiate
 USE QuadraturePoint_Method, ONLY: QuadraturePoint_Initiate => Initiate
 USE ReallocateUtility, ONLY: Reallocate
-USE RealVector_Method, ONLY: GetValue_, Get, GetValue
+USE RealVector_Method, ONLY: GetValue_
+USE RealVector_Method, ONLY: Get
+USE RealVector_Method, ONLY: GetValue
+USE Display_Method, ONLY: Display
 
 IMPLICIT NONE
 

--- a/src/submodules/ScalarField/src/ScalarField_Class@HDFMethods.F90
+++ b/src/submodules/ScalarField/src/ScalarField_Class@HDFMethods.F90
@@ -17,6 +17,7 @@
 
 SUBMODULE(ScalarField_Class) HDFMethods
 USE AbstractNodeField_Class, ONLY: AbstractNodeFieldImport
+USE AbstractNodeField_Class, ONLY: AbstractNodeFieldExport
 IMPLICIT NONE
 
 #ifdef DEBUG_VER
@@ -27,6 +28,28 @@ CHARACTER(*), PARAMETER :: modName = &
 CONTAINS
 
 !----------------------------------------------------------------------------
+!                                                                     Export
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE obj_Export
+#ifdef DEBUG_VER
+CHARACTER(*), PARAMETER :: myName = "obj_Export()"
+#endif
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[START] ')
+#endif
+
+CALL AbstractNodeFieldExport(obj=obj, hdf5=hdf5, group=group)
+
+#ifdef DEBUG_VER
+CALL e%RaiseInformation(modName//'::'//myName//' - '// &
+                        '[END] ')
+#endif
+END PROCEDURE obj_Export
+
+!----------------------------------------------------------------------------
 !                                                                    Import
 !----------------------------------------------------------------------------
 
@@ -34,10 +57,6 @@ MODULE PROCEDURE obj_Import
 #ifdef DEBUG_VER
 CHARACTER(*), PARAMETER :: myName = "obj_Import()"
 #endif
-
-TYPE(String) :: dsetname
-LOGICAL(LGT) :: bools(3)
-! TYPE(ParameterList_) :: param
 
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &
@@ -48,32 +67,10 @@ CALL AbstractNodeFieldImport(obj=obj, hdf5=hdf5, group=group, &
                              fedof=fedof, fedofs=fedofs, geofedof=geofedof, &
                              geofedofs=geofedofs)
 
-dsetname = TRIM(group)//"/tSize"
-bools(1) = hdf5%pathExists(dsetname%chars())
-dsetname = TRIM(group)//"/dof"
-bools(2) = hdf5%pathExists(dsetname%chars())
-dsetname = TRIM(group)//"/realVec"
-bools(3) = hdf5%pathExists(dsetname%chars())
-
-#ifdef DEBUG_VER
-CALL e%RaiseError(modName//'::'//myName//' - '// &
-                  '[WIP ERROR] :: This routine is under development')
-#endif
-
-! IF (.NOT. ALL(bools)) THEN
-!   CALL param%initiate()
-!   CALL SetScalarFieldParam(param=param, name=obj%name%chars(), &
-!                            engine=obj%engine%chars(), fieldType=obj%fieldType)
-!   obj%isInit = .FALSE.
-!   CALL obj%Initiate(param=param, fedof=fedof, geofedof=geofedof)
-!   CALL param%DEALLOCATE()
-! END IF
-
 #ifdef DEBUG_VER
 CALL e%RaiseInformation(modName//'::'//myName//' - '// &
                         '[END] ')
 #endif
-
 END PROCEDURE obj_Import
 
 !----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the field and I/O modules, mainly focused on reorganizing I/O methods for HDF5 and VTK, enhancing HDF5 utility support for character data, and cleaning up member variable placement in field classes. The changes improve modularity, clarity, and future extensibility for field data import/export operations.

**I/O Methods Refactoring and Enhancements:**

* Moved and reorganized HDF5 import/export interfaces from generic IOMethods to dedicated HDFMethods sections in both `AbstractField_Class` and `AbstractNodeField_Class`, clarifying their purpose and aligning with best practices. [[1]](diffhunk://#diff-ef38b3ad09485e5880740e5db447841e34a42e75cecaa187970cb5f3497d2006L595-R608) [[2]](diffhunk://#diff-ad08769646ce079d87a295645c17a55938fd895b17bb2484055e77f1075703f0L460-R460) [[3]](diffhunk://#diff-ad08769646ce079d87a295645c17a55938fd895b17bb2484055e77f1075703f0R1092-R1136)
* Updated VTK export interfaces to be grouped under `VTKMethods` instead of `IOMethods` for better separation of concerns.

**HDF5 Utility Extensions:**

* Added new public interfaces and subroutines in `HDF5FileUtility.F90` to support reading and writing character (string) vectors and matrices to HDF5 files, increasing flexibility for handling string data. [[1]](diffhunk://#diff-6f397e05fcb46c5e823b4c1c825c12d2a8c57fa2edceb30e9bd999c39e90572bR44-R59) [[2]](diffhunk://#diff-6f397e05fcb46c5e823b4c1c825c12d2a8c57fa2edceb30e9bd999c39e90572bR257-R310)

**Field Class Member Organization:**

* Relocated and grouped logical and string variables (such as `saveErrorNorm`, `plotWithResult`, `plotErrorNorm`, `name`, `engine`, `errorType`) in `AbstractField_Class` for clarity and maintainability. [[1]](diffhunk://#diff-ef38b3ad09485e5880740e5db447841e34a42e75cecaa187970cb5f3497d2006R86-L92) [[2]](diffhunk://#diff-ef38b3ad09485e5880740e5db447841e34a42e75cecaa187970cb5f3497d2006R116-R123) [[3]](diffhunk://#diff-ef38b3ad09485e5880740e5db447841e34a42e75cecaa187970cb5f3497d2006L133-L139)
* Fixed the placement of the `tSize` member in `AbstractNodeField_Class`, ensuring it is grouped with other internal-use variables. [[1]](diffhunk://#diff-ad08769646ce079d87a295645c17a55938fd895b17bb2484055e77f1075703f0R74-R77) [[2]](diffhunk://#diff-ad08769646ce079d87a295645c17a55938fd895b17bb2484055e77f1075703f0L89-L92)

**ScalarField Module Updates:**

* Added and exposed a public `ScalarFieldExport` method and reorganized method groupings in `ScalarField_Class` to use new HDF and VTK method sections, improving interface clarity and consistency. [[1]](diffhunk://#diff-deba0cfe6ade5410229c8356b852c0a8767123fc87e6f714c510359245104cfeR47) [[2]](diffhunk://#diff-deba0cfe6ade5410229c8356b852c0a8767123fc87e6f714c510359245104cfeL166-R169)

**Minor Cleanups:**

* Removed redundant comments and improved grouping of methods for clarity in `ScalarField_Class`. [[1]](diffhunk://#diff-deba0cfe6ade5410229c8356b852c0a8767123fc87e6f714c510359245104cfeL68-L74) [[2]](diffhunk://#diff-deba0cfe6ade5410229c8356b852c0a8767123fc87e6f714c510359245104cfeL102) [[3]](diffhunk://#diff-deba0cfe6ade5410229c8356b852c0a8767123fc87e6f714c510359245104cfeL122) [[4]](diffhunk://#diff-deba0cfe6ade5410229c8356b852c0a8767123fc87e6f714c510359245104cfeL136-L141) [[5]](diffhunk://#diff-deba0cfe6ade5410229c8356b852c0a8767123fc87e6f714c510359245104cfeL153)

These changes collectively make the codebase easier to maintain, extend, and understand, especially regarding field data I/O operations.